### PR TITLE
feat: define personal memory DWN protocol

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ export default [
       parserOptions: {
         ecmaFeatures : { modules: true },
         ecmaVersion  : 'latest',
-        project      : true,
+        project      : './tsconfig.eslint.json',
         tsconfigRootDir: import.meta.dirname,
       },
       globals: {

--- a/schemas/collection.json
+++ b/schemas/collection.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory/collection",
+  "type": "object",
+  "properties": {
+    "description": { "type": "string", "description": "Description of the collection" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fact.json
+++ b/schemas/fact.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory/fact",
+  "type": "object",
+  "properties": {
+    "content": { "type": "string", "description": "The fact content" },
+    "context": { "type": "string", "description": "Optional context or source information" }
+  },
+  "required": ["content"],
+  "additionalProperties": false
+}

--- a/schemas/preference.json
+++ b/schemas/preference.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory/preference",
+  "type": "object",
+  "properties": {
+    "content": { "type": "string", "description": "The preference content" },
+    "context": { "type": "string", "description": "Optional context" }
+  },
+  "required": ["content"],
+  "additionalProperties": false
+}

--- a/schemas/relationship.json
+++ b/schemas/relationship.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory/relationship",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Name of the person/entity" },
+    "notes": { "type": "string", "description": "Optional notes about the relationship" }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/schemas/supersession.json
+++ b/schemas/supersession.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory/supersession",
+  "type": "object",
+  "properties": {
+    "reason": { "type": "string", "description": "Why this fact was superseded" }
+  },
+  "additionalProperties": false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 // memoryd — User-owned AI memory layer with task graph, built on DWN protocols.
 // This is the barrel export for the @enbox/memoryd package.
 
-export {};
+export { MemoryProtocol } from './protocols/memory.js';
+export type { CollectionData, FactData, PreferenceData, RelationshipData, SupersessionData } from './protocols/memory.js';

--- a/src/protocols/memory.ts
+++ b/src/protocols/memory.ts
@@ -1,0 +1,156 @@
+import { defineProtocol } from '@enbox/api';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+// ---------------------------------------------------------------------------
+// Data types — mirror the JSON schemas in schemas/
+// ---------------------------------------------------------------------------
+
+export type FactData = {
+  content : string;
+  context?: string;
+};
+
+export type PreferenceData = {
+  content : string;
+  context?: string;
+};
+
+export type RelationshipData = {
+  name : string;
+  notes?: string;
+};
+
+export type CollectionData = {
+  description?: string;
+};
+
+export type SupersessionData = {
+  reason?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Schema map — associates TS types with protocol type names
+// ---------------------------------------------------------------------------
+
+type MemorySchemaMap = {
+  fact : FactData;
+  preference : PreferenceData;
+  relationship : RelationshipData;
+  collection : CollectionData;
+  agent : Record<string, never>;
+  supersession : SupersessionData;
+};
+
+// ---------------------------------------------------------------------------
+// Protocol definition
+// ---------------------------------------------------------------------------
+
+const SCHEMA_BASE = 'https://enbox.org/schemas/memory';
+
+const MemoryDefinition = {
+  protocol  : 'https://enbox.org/protocols/memory/v1',
+  published : false,
+  types     : {
+    fact: {
+      schema             : `${SCHEMA_BASE}/fact`,
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
+    },
+    preference: {
+      schema             : `${SCHEMA_BASE}/preference`,
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
+    },
+    relationship: {
+      schema             : `${SCHEMA_BASE}/relationship`,
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
+    },
+    collection: {
+      schema      : `${SCHEMA_BASE}/collection`,
+      dataFormats : ['application/json'],
+    },
+    agent        : {},
+    supersession : {
+      schema      : `${SCHEMA_BASE}/supersession`,
+      dataFormats : ['application/json'],
+    },
+  },
+  structure: {
+    fact: {
+      agent : { $role: true },
+      $tags : {
+        $requiredTags       : ['category', 'source'],
+        $allowUndefinedTags : false,
+        category            : { type: 'string' },
+        source              : { type: 'string' },
+        confidence          : { type: 'number', minimum: 0, maximum: 1 },
+        status              : { type: 'string', enum: ['active', 'superseded', 'archived'] },
+        collection          : { type: 'string' },
+      },
+      $actions: [
+        { role: 'fact/agent', can: ['create', 'read'] },
+        { who: 'author', of: 'fact', can: ['create', 'read', 'update', 'delete'] },
+      ],
+      supersession: {
+        $immutable : true,
+        $tags      : {
+          $requiredTags       : ['supersededBy'],
+          $allowUndefinedTags : false,
+          supersededBy        : { type: 'string' },
+        },
+        $actions: [
+          { role: 'fact/agent', can: ['create', 'read'] },
+          { who: 'author', of: 'fact', can: ['create', 'read'] },
+        ],
+      },
+    },
+    preference: {
+      agent : { $role: true },
+      $tags : {
+        $requiredTags       : ['domain'],
+        $allowUndefinedTags : false,
+        domain              : { type: 'string' },
+        collection          : { type: 'string' },
+      },
+      $actions: [
+        { role: 'preference/agent', can: ['create', 'read'] },
+        { who: 'author', of: 'preference', can: ['create', 'read', 'update', 'delete'] },
+      ],
+    },
+    relationship: {
+      agent : { $role: true },
+      $tags : {
+        $requiredTags       : ['name', 'type'],
+        $allowUndefinedTags : false,
+        name                : { type: 'string' },
+        type                : { type: 'string', enum: ['person', 'org', 'project', 'tool'] },
+        collection          : { type: 'string' },
+      },
+      $actions: [
+        { role: 'relationship/agent', can: ['create', 'read'] },
+        { who: 'author', of: 'relationship', can: ['create', 'read', 'update', 'delete'] },
+      ],
+    },
+    collection: {
+      $tags: {
+        $requiredTags       : ['name'],
+        $allowUndefinedTags : false,
+        name                : { type: 'string' },
+      },
+      $actions: [
+        { who: 'anyone', can: ['read'] },
+        { who: 'author', of: 'collection', can: ['create', 'read', 'update', 'delete'] },
+      ],
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+// ---------------------------------------------------------------------------
+// Typed protocol export
+// ---------------------------------------------------------------------------
+
+export const MemoryProtocol = defineProtocol<typeof MemoryDefinition, MemorySchemaMap>(
+  MemoryDefinition,
+  {} as MemorySchemaMap,
+);

--- a/tests/protocols/memory.spec.ts
+++ b/tests/protocols/memory.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'bun:test';
+
+import { MemoryProtocol } from '../../src/protocols/memory.js';
+
+const def = MemoryProtocol.definition;
+
+describe('MemoryProtocol', () => {
+  // -----------------------------------------------------------------------
+  // Top-level metadata
+  // -----------------------------------------------------------------------
+
+  it('has the correct protocol URI', () => {
+    expect(def.protocol).toBe('https://enbox.org/protocols/memory/v1');
+  });
+
+  it('is not published', () => {
+    expect(def.published).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Types
+  // -----------------------------------------------------------------------
+
+  it('declares all expected types', () => {
+    const typeNames = Object.keys(def.types).sort();
+    expect(typeNames).toEqual(
+      ['agent', 'collection', 'fact', 'preference', 'relationship', 'supersession'],
+    );
+  });
+
+  it('requires encryption for fact', () => {
+    expect(def.types.fact.encryptionRequired).toBe(true);
+  });
+
+  it('requires encryption for preference', () => {
+    expect(def.types.preference.encryptionRequired).toBe(true);
+  });
+
+  it('requires encryption for relationship', () => {
+    expect(def.types.relationship.encryptionRequired).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Fact structure
+  // -----------------------------------------------------------------------
+
+  describe('fact structure', () => {
+    const fact = def.structure.fact;
+
+    it('has required tags: category, source', () => {
+      expect(fact.$tags?.$requiredTags).toEqual(['category', 'source']);
+    });
+
+    it('has an agent role record', () => {
+      expect((fact as Record<string, unknown>).agent).toEqual({ $role: true });
+    });
+
+    it('nests supersession under fact', () => {
+      const supersession = (fact as Record<string, unknown>).supersession as Record<string, unknown>;
+      expect(supersession).toBeDefined();
+    });
+
+    it('marks supersession as $immutable', () => {
+      const supersession = (fact as Record<string, unknown>).supersession as Record<string, unknown>;
+      expect(supersession.$immutable).toBe(true);
+    });
+
+    it('supersession has required tag: supersededBy', () => {
+      const supersession = (fact as Record<string, unknown>).supersession as Record<string, unknown>;
+      const tags = supersession.$tags as Record<string, unknown>;
+      expect(tags.$requiredTags).toEqual(['supersededBy']);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Preference structure
+  // -----------------------------------------------------------------------
+
+  describe('preference structure', () => {
+    const preference = def.structure.preference;
+
+    it('has required tags: domain', () => {
+      expect(preference.$tags?.$requiredTags).toEqual(['domain']);
+    });
+
+    it('has an agent role record', () => {
+      expect((preference as Record<string, unknown>).agent).toEqual({ $role: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Relationship structure
+  // -----------------------------------------------------------------------
+
+  describe('relationship structure', () => {
+    const relationship = def.structure.relationship;
+
+    it('has required tags: name, type', () => {
+      expect(relationship.$tags?.$requiredTags).toEqual(['name', 'type']);
+    });
+
+    it('has an agent role record', () => {
+      expect((relationship as Record<string, unknown>).agent).toEqual({ $role: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Collection structure
+  // -----------------------------------------------------------------------
+
+  describe('collection structure', () => {
+    const collection = def.structure.collection;
+
+    it('has required tags: name', () => {
+      expect(collection.$tags?.$requiredTags).toEqual(['name']);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Agent role records
+  // -----------------------------------------------------------------------
+
+  describe('agent role records', () => {
+    it('fact/agent has $role: true', () => {
+      const agent = (def.structure.fact as Record<string, unknown>).agent as Record<string, unknown>;
+      expect(agent.$role).toBe(true);
+    });
+
+    it('preference/agent has $role: true', () => {
+      const agent = (def.structure.preference as Record<string, unknown>).agent as Record<string, unknown>;
+      expect(agent.$role).toBe(true);
+    });
+
+    it('relationship/agent has $role: true', () => {
+      const agent = (def.structure.relationship as Record<string, unknown>).agent as Record<string, unknown>;
+      expect(agent.$role).toBe(true);
+    });
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Defines the `memory/v1` DWN protocol — the personal memory layer for facts, preferences, relationships, and collections. (Issue #2)

- **`MemoryProtocol`** at `https://enbox.org/protocols/memory/v1` via `defineProtocol()` with full `SchemaMap` typing
- **6 record types**: `fact`, `preference`, `relationship`, `collection`, `agent` (role), `supersession` (immutable sub-record)
- **Encryption required** on `fact`, `preference`, `relationship`
- **Agent role records** nested under each protected type for scoped delegated access
- **Supersession chain**: immutable `supersession` sub-records under `fact` with `supersededBy` tag
- **5 JSON schemas** in `schemas/` for all data-bearing record types
- **19 passing tests** covering protocol metadata, types, structure, tags, roles, and immutability
- Adds `tsconfig.eslint.json` so ESLint can parse test files

## Quality gates

```
bun run build   ✅ Zero TypeScript errors
bun run lint    ✅ Zero ESLint warnings/errors
bun test        ✅ 19 pass, 0 fail
```

Closes #2