### PR TITLE
feat: define task graph DWN protocol

### DIFF
--- a/schemas/dependency.json
+++ b/schemas/dependency.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/task-graph/dependency",
+  "type": "object",
+  "properties": {
+    "description": { "type": "string", "description": "Description of the dependency relationship" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/note.json
+++ b/schemas/note.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/task-graph/note",
+  "type": "object",
+  "properties": {
+    "content": { "type": "string", "description": "Note content" }
+  },
+  "required": ["content"],
+  "additionalProperties": false
+}

--- a/schemas/status-change.json
+++ b/schemas/status-change.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/task-graph/status-change",
+  "type": "object",
+  "properties": {
+    "reason": { "type": "string", "description": "Reason for status change" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/task.json
+++ b/schemas/task.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/task-graph/task",
+  "type": "object",
+  "properties": {
+    "title": { "type": "string", "description": "Task title" },
+    "description": { "type": "string", "description": "Detailed task description" }
+  },
+  "required": ["title"],
+  "additionalProperties": false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,6 @@
 
 export { MemoryProtocol } from './protocols/memory.js';
 export type { CollectionData, FactData, PreferenceData, RelationshipData, SupersessionData } from './protocols/memory.js';
+
+export { TaskGraphProtocol } from './protocols/task-graph.js';
+export type { DependencyData, NoteData, StatusChangeData, TaskData } from './protocols/task-graph.js';

--- a/src/protocols/task-graph.ts
+++ b/src/protocols/task-graph.ts
@@ -1,0 +1,162 @@
+import { defineProtocol } from '@enbox/api';
+import type { ProtocolDefinition, ProtocolRuleSet } from '@enbox/dwn-sdk-js';
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+export type TaskData = {
+  title: string;
+  description?: string;
+};
+
+export type DependencyData = {
+  description?: string;
+};
+
+export type StatusChangeData = {
+  reason?: string;
+};
+
+export type NoteData = {
+  content: string;
+};
+
+// ---------------------------------------------------------------------------
+// Schema map
+// ---------------------------------------------------------------------------
+
+type TaskGraphSchemaMap = {
+  task: TaskData;
+  dependency: DependencyData;
+  statusChange: StatusChangeData;
+  note: NoteData;
+  agent: Record<string, never>;
+};
+
+// ---------------------------------------------------------------------------
+// Shared fragments (mutable arrays for ProtocolDefinition compat)
+// ---------------------------------------------------------------------------
+
+const statusEnum = ['open', 'in_progress', 'blocked', 'closed'];
+const priorityEnum = ['p0', 'p1', 'p2', 'p3', 'p4'];
+const taskTypeEnum = ['epic', 'feature', 'bug', 'task', 'chore'];
+const depTypeEnum = ['blocks', 'relates_to', 'duplicates', 'supersedes'];
+
+function taskTags(): ProtocolRuleSet['$tags'] {
+  return {
+    $requiredTags       : ['status', 'priority'],
+    $allowUndefinedTags : false,
+    status              : { type: 'string', enum: [...statusEnum] },
+    priority            : { type: 'string', enum: [...priorityEnum] },
+    type                : { type: 'string', enum: [...taskTypeEnum] },
+    assignee            : { type: 'string' },
+    collection          : { type: 'string' },
+  };
+}
+
+function taskActions(): ProtocolRuleSet['$actions'] {
+  return [
+    { role: 'task/agent', can: ['create', 'read', 'update'] },
+    { who: 'author', of: 'task', can: ['create', 'read', 'update', 'delete'] },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Protocol definition
+// ---------------------------------------------------------------------------
+
+const definition = {
+  protocol  : 'https://enbox.org/protocols/task-graph/v1',
+  published : false,
+  types     : {
+    task: {
+      schema             : 'https://enbox.org/schemas/task-graph/task',
+      dataFormats        : ['application/json'],
+      encryptionRequired : true,
+    },
+    dependency: {
+      schema      : 'https://enbox.org/schemas/task-graph/dependency',
+      dataFormats : ['application/json'],
+    },
+    statusChange: {
+      schema      : 'https://enbox.org/schemas/task-graph/status-change',
+      dataFormats : ['application/json'],
+    },
+    note: {
+      schema      : 'https://enbox.org/schemas/task-graph/note',
+      dataFormats : ['application/json'],
+    },
+    agent: {},
+  },
+  structure: {
+    task: {
+      $tags    : taskTags(),
+      $actions : taskActions(),
+
+      agent: {
+        $role: true,
+      },
+
+      // 2nd-level subtask
+      task: {
+        $tags    : taskTags(),
+        $actions : taskActions(),
+
+        // 3rd-level subtask
+        task: {
+          $tags    : taskTags(),
+          $actions : taskActions(),
+        },
+      },
+
+      dependency: {
+        $immutable : true,
+        $tags      : {
+          $requiredTags       : ['type', 'targetId'],
+          $allowUndefinedTags : false,
+          type                : { type: 'string', enum: [...depTypeEnum] },
+          targetId            : { type: 'string' },
+        },
+        $actions: [
+          { role: 'task/agent', can: ['create', 'read'] },
+          { who: 'author', of: 'task', can: ['create', 'read'] },
+        ],
+      },
+
+      statusChange: {
+        $immutable : true,
+        $tags      : {
+          $requiredTags       : ['from', 'to'],
+          $allowUndefinedTags : false,
+          from                : { type: 'string', enum: [...statusEnum] },
+          to                  : { type: 'string', enum: [...statusEnum] },
+          reason              : { type: 'string' },
+        },
+        $actions: [
+          { role: 'task/agent', can: ['create', 'read'] },
+          { who: 'author', of: 'task', can: ['create', 'read'] },
+        ],
+      },
+
+      note: {
+        $tags: {
+          $allowUndefinedTags: false,
+        },
+        $actions: [
+          { role: 'task/agent', can: ['create', 'read'] },
+          { who: 'author', of: 'task', can: ['create', 'read', 'update', 'delete'] },
+        ],
+      },
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+// ---------------------------------------------------------------------------
+// Typed protocol export
+// ---------------------------------------------------------------------------
+
+export const TaskGraphProtocol = defineProtocol(
+  definition,
+  {} as TaskGraphSchemaMap,
+);

--- a/tests/protocols/task-graph.spec.ts
+++ b/tests/protocols/task-graph.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test';
+
+import { TaskGraphProtocol } from '../../src/protocols/task-graph.js';
+
+const def = TaskGraphProtocol.definition;
+
+describe('TaskGraphProtocol', () => {
+  it('has the correct protocol URI', () => {
+    expect(def.protocol).toBe('https://enbox.org/protocols/task-graph/v1');
+  });
+
+  it('is not published', () => {
+    expect(def.published).toBe(false);
+  });
+
+  it('defines all expected types', () => {
+    const typeNames = Object.keys(def.types);
+    expect(typeNames).toContain('task');
+    expect(typeNames).toContain('dependency');
+    expect(typeNames).toContain('statusChange');
+    expect(typeNames).toContain('note');
+    expect(typeNames).toContain('agent');
+  });
+
+  it('task type has encryptionRequired: true', () => {
+    expect(def.types.task.encryptionRequired).toBe(true);
+  });
+
+  it('task structure has required tags (status, priority)', () => {
+    const taskRule = def.structure.task;
+    expect(taskRule.$tags).toBeDefined();
+    const tags = taskRule.$tags!;
+    expect(tags.$requiredTags).toContain('status');
+    expect(tags.$requiredTags).toContain('priority');
+  });
+
+  it('task status tag has correct enum values', () => {
+    const tags = def.structure.task.$tags!;
+    const statusTag = tags.status as { type: string; enum: string[] };
+    expect(statusTag.enum).toEqual(['open', 'in_progress', 'blocked', 'closed']);
+  });
+
+  it('task priority tag has correct enum values', () => {
+    const tags = def.structure.task.$tags!;
+    const priorityTag = tags.priority as { type: string; enum: string[] };
+    expect(priorityTag.enum).toEqual(['p0', 'p1', 'p2', 'p3', 'p4']);
+  });
+
+  it('dependency is $immutable', () => {
+    const depRule = def.structure.task.dependency as { $immutable?: boolean };
+    expect(depRule.$immutable).toBe(true);
+  });
+
+  it('statusChange is $immutable', () => {
+    const scRule = def.structure.task.statusChange as { $immutable?: boolean };
+    expect(scRule.$immutable).toBe(true);
+  });
+
+  it('dependency has required tags (type, targetId)', () => {
+    const depRule = def.structure.task.dependency as { $tags?: { $requiredTags?: string[] } };
+    expect(depRule.$tags).toBeDefined();
+    expect(depRule.$tags!.$requiredTags).toContain('type');
+    expect(depRule.$tags!.$requiredTags).toContain('targetId');
+  });
+
+  it('statusChange has required tags (from, to)', () => {
+    const scRule = def.structure.task.statusChange as { $tags?: { $requiredTags?: string[] } };
+    expect(scRule.$tags).toBeDefined();
+    expect(scRule.$tags!.$requiredTags).toContain('from');
+    expect(scRule.$tags!.$requiredTags).toContain('to');
+  });
+
+  it('supports recursive task nesting (task > task > task)', () => {
+    const level1 = def.structure.task;
+    expect(level1.task).toBeDefined();
+
+    const level2 = level1.task as typeof level1;
+    expect(level2.task).toBeDefined();
+
+    const level3 = level2.task as typeof level1;
+    expect(level3.$tags).toBeDefined();
+    expect(level3.$actions).toBeDefined();
+  });
+
+  it('agent role record exists with $role: true', () => {
+    const agentRule = def.structure.task.agent as { $role?: boolean };
+    expect(agentRule.$role).toBe(true);
+  });
+
+  it('note structure exists under task', () => {
+    const noteRule = def.structure.task.note as { $actions?: unknown[] };
+    expect(noteRule).toBeDefined();
+    expect(noteRule.$actions).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Defines the `task-graph/v1` DWN protocol — the dependency-aware task graph inspired by Beads. (Issue #3)

- **`TaskGraphProtocol`** at `https://enbox.org/protocols/task-graph/v1` via `defineProtocol()` with full `SchemaMap` typing
- **5 record types**: `task` (encrypted), `dependency` (immutable), `statusChange` (immutable), `note`, `agent` (role)
- **Recursive task nesting**: 3 levels deep (`task/task/task`) for epic > feature > subtask hierarchy
- **Immutable audit trail**: `dependency` and `statusChange` records are `$immutable`
- **Rich tag system**: status (open/in_progress/blocked/closed), priority (p0-p4), type (epic/feature/bug/task/chore), assignee, collection
- **Dependency types**: blocks, relates_to, duplicates, supersedes
- **4 JSON schemas** in `schemas/` for all data-bearing record types
- **14 passing tests** covering protocol metadata, types, nesting, tags, enum values, immutability, roles
- Adds `tsconfig.eslint.json` so ESLint can parse test files

## Quality gates

```
bun run build   ✅ Zero TypeScript errors
bun run lint    ✅ Zero ESLint warnings/errors
bun test        ✅ 14 pass, 0 fail
```

Closes #3