### PR TITLE
feat: define audit log DWN protocol

### DIFF
--- a/schemas/action-log.json
+++ b/schemas/action-log.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://enbox.org/schemas/memory-audit/action-log",
+  "type": "object",
+  "properties": {
+    "description": { "type": "string", "description": "Human-readable description of the action" },
+    "details": { "type": "object", "description": "Additional action-specific details" }
+  },
+  "additionalProperties": false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export type { CollectionData, FactData, PreferenceData, RelationshipData, Supers
 
 export { TaskGraphProtocol } from './protocols/task-graph.js';
 export type { DependencyData, NoteData, StatusChangeData, TaskData } from './protocols/task-graph.js';
+
+export { AuditProtocol } from './protocols/audit.js';
+export type { ActionLogData } from './protocols/audit.js';

--- a/src/protocols/audit.ts
+++ b/src/protocols/audit.ts
@@ -1,0 +1,62 @@
+import { defineProtocol } from '@enbox/api';
+import type { ProtocolDefinition } from '@enbox/dwn-sdk-js';
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+export type ActionLogData = {
+  description? : string;
+  details? : Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Schema map
+// ---------------------------------------------------------------------------
+
+type AuditSchemaMap = {
+  actionLog : ActionLogData;
+  agent : Record<string, never>;
+};
+
+// ---------------------------------------------------------------------------
+// Protocol definition
+// ---------------------------------------------------------------------------
+
+const definition = {
+  protocol  : 'https://enbox.org/protocols/memory-audit/v1',
+  published : false,
+  types     : {
+    actionLog: {
+      schema      : 'https://enbox.org/schemas/memory-audit/action-log',
+      dataFormats : ['application/json'],
+    },
+    agent: {},
+  },
+  structure: {
+    actionLog: {
+      $immutable : true,
+      $tags      : {
+        $requiredTags       : ['agentDid', 'action', 'targetProtocol', 'targetRecordId', 'status'],
+        $allowUndefinedTags : false,
+        agentDid            : { type: 'string' },
+        action              : { type: 'string' },
+        targetProtocol      : { type: 'string' },
+        targetRecordId      : { type: 'string' },
+        status              : { type: 'string', enum: ['success', 'failed'] },
+      },
+      $actions: [
+        { role: 'actionLog/agent', can: ['create', 'read'] },
+        { who: 'author', of: 'actionLog', can: ['create', 'read'] },
+      ],
+      agent: {
+        $role: true,
+      },
+    },
+  },
+} as const satisfies ProtocolDefinition;
+
+export const AuditProtocol = defineProtocol<typeof definition, AuditSchemaMap>(
+  definition,
+  {} as AuditSchemaMap,
+);

--- a/tests/protocols/audit.spec.ts
+++ b/tests/protocols/audit.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AuditProtocol } from '../../src/protocols/audit.js';
+
+const def = AuditProtocol.definition;
+
+describe('AuditProtocol', () => {
+  it('has the correct protocol URI', () => {
+    expect(def.protocol).toBe('https://enbox.org/protocols/memory-audit/v1');
+  });
+
+  it('is not published', () => {
+    expect(def.published).toBe(false);
+  });
+
+  it('declares all expected types', () => {
+    expect(Object.keys(def.types)).toEqual(
+      expect.arrayContaining(['actionLog', 'agent']),
+    );
+  });
+
+  it('marks actionLog as $immutable', () => {
+    expect(def.structure.actionLog.$immutable).toBe(true);
+  });
+
+  it('requires all five tags on actionLog', () => {
+    const tags = def.structure.actionLog.$tags;
+    expect(tags?.$requiredTags).toEqual([
+      'agentDid',
+      'action',
+      'targetProtocol',
+      'targetRecordId',
+      'status',
+    ]);
+  });
+
+  it('constrains status tag to success | failed', () => {
+    const status = def.structure.actionLog.$tags?.status;
+    expect(status).toBeDefined();
+    expect((status as { enum: string[] }).enum).toEqual(['success', 'failed']);
+  });
+
+  it('defines agent as a $role record', () => {
+    const agent = def.structure.actionLog.agent;
+    expect(agent).toBeDefined();
+    expect((agent as { $role: boolean }).$role).toBe(true);
+  });
+
+  it('allows actionLog/agent role to create and read', () => {
+    const actions = def.structure.actionLog.$actions;
+    expect(actions).toBeDefined();
+    const roleAction = actions?.find(
+      (a) => 'role' in a && a.role === 'actionLog/agent',
+    );
+    expect(roleAction).toBeDefined();
+    expect(roleAction!.can).toEqual(['create', 'read']);
+  });
+
+  it('allows author of actionLog to create and read', () => {
+    const actions = def.structure.actionLog.$actions;
+    expect(actions).toBeDefined();
+    const authorAction = actions?.find(
+      (a) => 'who' in a && a.who === 'author' && 'of' in a && a.of === 'actionLog',
+    );
+    expect(authorAction).toBeDefined();
+    expect(authorAction!.can).toEqual(['create', 'read']);
+  });
+});


### PR DESCRIPTION
## Summary

Defines the `memory-audit/v1` DWN protocol — the append-only audit trail for all agent actions. (Issue #4)

- **`AuditProtocol`** at `https://enbox.org/protocols/memory-audit/v1` via `defineProtocol()` with full `SchemaMap` typing
- **2 record types**: `actionLog` (immutable), `agent` (role)
- **Immutable audit trail**: `actionLog` records are `$immutable` — append-only, never modified
- **Required tags**: `agentDid`, `action`, `targetProtocol`, `targetRecordId`, `status` (success/failed)
- **Agent role** for delegated audit log writing by external agents
- **1 JSON schema** in `schemas/action-log.json`
- **9 passing tests** covering protocol metadata, immutability, tags, enum values, role records, action rules
- Adds `tsconfig.eslint.json` so ESLint can parse test files

## Quality gates

```
bun run build   ✅ Zero TypeScript errors
bun run lint    ✅ Zero ESLint warnings/errors
bun test        ✅ 9 pass, 0 fail
```

Closes #4