### PR TITLE
feat: add MemoryStore for DWN memory CRUD operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.tgz
 .DS_Store
 *.log
+__TESTDATA__/

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
+        "@enbox/agent": "0.2.0",
         "@eslint/js": "9.7.0",
         "@stylistic/eslint-plugin": "^5.9.0",
         "@typescript-eslint/eslint-plugin": "8.32.1",
@@ -491,7 +492,7 @@
 
     "layerr": ["layerr@2.1.0", "", {}, "sha512-xDD9suWxfBYeXgqffRVH/Wqh+mqZrQcqPRn0I0ijl7iJQ7vu8gMGPt1Qop59pEW/jaIDNUN7+PX1Qk40+vuflg=="],
 
-    "level": ["level@8.0.1", "", { "dependencies": { "abstract-level": "^1.0.4", "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ=="],
+    "level": ["level@8.0.0", "", { "dependencies": { "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ=="],
 
     "level-supports": ["level-supports@4.0.1", "", {}, "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA=="],
 
@@ -777,17 +778,17 @@
 
     "@decentralized-identity/ion-sdk/multiformats": ["multiformats@12.1.3", "", {}, "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="],
 
-    "@enbox/agent/level": ["level@8.0.0", "", { "dependencies": { "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ=="],
+    "@enbox/common/level": ["level@8.0.1", "", { "dependencies": { "abstract-level": "^1.0.4", "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ=="],
 
     "@enbox/common/multiformats": ["multiformats@13.1.0", "", {}, "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="],
+
+    "@enbox/dids/level": ["level@8.0.1", "", { "dependencies": { "abstract-level": "^1.0.4", "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ=="],
 
     "@enbox/dwn-sdk-js/@noble/curves": ["@noble/curves@1.4.2", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw=="],
 
     "@enbox/dwn-sdk-js/abstract-level": ["abstract-level@1.0.3", "", { "dependencies": { "buffer": "^6.0.3", "catering": "^2.1.0", "is-buffer": "^2.0.5", "level-supports": "^4.0.0", "level-transcoder": "^1.0.1", "module-error": "^1.0.1", "queue-microtask": "^1.2.3" } }, "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA=="],
 
     "@enbox/dwn-sdk-js/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "@enbox/dwn-sdk-js/level": ["level@8.0.0", "", { "dependencies": { "browser-level": "^1.0.1", "classic-level": "^1.2.0" } }, "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
+    "@enbox/agent": "0.2.0",
     "@eslint/js": "9.7.0",
     "@stylistic/eslint-plugin": "^5.9.0",
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/src/core/memory-store.ts
+++ b/src/core/memory-store.ts
@@ -1,0 +1,495 @@
+import type { FactData, PreferenceData, RelationshipData } from '../protocols/memory.js';
+import type { PaginationCursor, ProtocolDefinition } from '@enbox/dwn-sdk-js';
+import type { SchemaMap, TypedProtocol, TypedWeb5, Web5 } from '@enbox/api';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+import { MemoryProtocol } from '../protocols/memory.js';
+
+// ---------------------------------------------------------------------------
+// Extract definition and schema map types from the typed protocol
+// ---------------------------------------------------------------------------
+
+type InferDef<P> = P extends TypedProtocol<infer D, infer _M> ? D : ProtocolDefinition;
+type InferMap<P> = P extends TypedProtocol<infer _D, infer M> ? M : SchemaMap;
+
+type MemoryDef = InferDef<typeof MemoryProtocol>;
+type MemoryMap = InferMap<typeof MemoryProtocol>;
+type MemoryTyped = TypedWeb5<MemoryDef, MemoryMap>;
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type RecordResult = {
+  id : string;
+  contextId : string | undefined;
+  status : { code: number; detail: string };
+};
+
+export type FactRecord = {
+  id : string;
+  contextId : string | undefined;
+  data : FactData;
+  tags : { category: string; source: string; confidence?: number; status?: string; collection?: string };
+  dateCreated : string;
+};
+
+export type PreferenceRecord = {
+  id : string;
+  contextId : string | undefined;
+  data : PreferenceData;
+  tags : { domain: string; collection?: string };
+  dateCreated : string;
+};
+
+export type RelationshipRecord = {
+  id : string;
+  contextId : string | undefined;
+  data : RelationshipData;
+  tags : { name: string; type: string; collection?: string };
+  dateCreated : string;
+};
+
+export type ListResult<T> = {
+  records : T[];
+  cursor? : PaginationCursor;
+};
+
+export type FactFilters = {
+  category? : string;
+  source? : string;
+  status? : string;
+  collection? : string;
+};
+
+export type PreferenceFilters = {
+  domain? : string;
+  collection? : string;
+};
+
+export type RelationshipFilters = {
+  name? : string;
+  type? : string;
+  collection? : string;
+};
+
+export type PaginationOptions = {
+  limit? : number;
+  cursor? : PaginationCursor;
+};
+
+// ---------------------------------------------------------------------------
+// Tag record alias
+// ---------------------------------------------------------------------------
+
+type TagRecord = Record<string, string | number | boolean | string[] | number[]>;
+
+// ---------------------------------------------------------------------------
+// MemoryStore class
+// ---------------------------------------------------------------------------
+
+export class MemoryStore {
+  private readonly typed: MemoryTyped;
+  private configured = false;
+
+  constructor(web5: Web5) {
+    this.typed = web5.using(MemoryProtocol);
+  }
+
+  /** Ensure the protocol is configured (idempotent). */
+  private async ensureConfigured(): Promise<void> {
+    if (!this.configured) {
+      await this.typed.configure({ encryption: true });
+      this.configured = true;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Facts
+  // -------------------------------------------------------------------------
+
+  async addFact(content: string, category: string, source: string, opts?: {
+    context? : string;
+    confidence? : number;
+    collection? : string;
+  }): Promise<RecordResult> {
+    await this.ensureConfigured();
+    const tags: Record<string, string | number> = {
+      category,
+      source,
+      status: 'active',
+    };
+    if (opts?.confidence !== undefined) { tags.confidence = opts.confidence; }
+    if (opts?.collection !== undefined) { tags.collection = opts.collection; }
+
+    const { status, record } = await this.typed.records.create('fact', {
+      data       : { content, context: opts?.context },
+      tags,
+      encryption : true,
+    });
+
+    if (status.code !== 202) {
+      throw new Error(`addFact failed: ${status.code} ${status.detail}`);
+    }
+
+    return { id: record.id, contextId: record.contextId, status };
+  }
+
+  async getFact(recordId: string): Promise<FactRecord> {
+    await this.ensureConfigured();
+    const { status, record } = await this.typed.records.read('fact', {
+      filter     : { recordId },
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`getFact failed: ${status.code} ${status.detail}`);
+    }
+
+    const data = await record.data.json() as FactData;
+    const tags = record.tags as TagRecord | undefined;
+
+    return {
+      id        : record.id,
+      contextId : record.contextId,
+      data,
+      tags      : {
+        category   : tags?.category as string,
+        source     : tags?.source as string,
+        confidence : tags?.confidence as number | undefined,
+        status     : tags?.status as string | undefined,
+        collection : tags?.collection as string | undefined,
+      },
+      dateCreated: record.dateCreated,
+    };
+  }
+
+  async listFacts(filters?: FactFilters, pagination?: PaginationOptions): Promise<ListResult<FactRecord>> {
+    await this.ensureConfigured();
+    const tags: Record<string, string | number> = {};
+    if (filters?.category !== undefined) { tags.category = filters.category; }
+    if (filters?.source !== undefined) { tags.source = filters.source; }
+    if (filters?.status !== undefined) { tags.status = filters.status; }
+    if (filters?.collection !== undefined) { tags.collection = filters.collection; }
+
+    const { status, records, cursor } = await this.typed.records.query('fact', {
+      filter     : Object.keys(tags).length > 0 ? { tags } : undefined,
+      dateSort   : DateSort.CreatedDescending,
+      pagination,
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`listFacts failed: ${status.code} ${status.detail}`);
+    }
+
+    const results: FactRecord[] = [];
+    for (const record of records) {
+      const data = await record.data.json() as FactData;
+      const rTags = record.tags as TagRecord | undefined;
+      results.push({
+        id        : record.id,
+        contextId : record.contextId,
+        data,
+        tags      : {
+          category   : rTags?.category as string,
+          source     : rTags?.source as string,
+          confidence : rTags?.confidence as number | undefined,
+          status     : rTags?.status as string | undefined,
+          collection : rTags?.collection as string | undefined,
+        },
+        dateCreated: record.dateCreated,
+      });
+    }
+
+    return { records: results, cursor };
+  }
+
+  async updateFact(recordId: string, updates: {
+    content? : string;
+    context? : string;
+    confidence? : number;
+    status? : string;
+  }): Promise<RecordResult> {
+    await this.ensureConfigured();
+    const { status: readStatus, record } = await this.typed.records.read('fact', {
+      filter     : { recordId },
+      encryption : true,
+    });
+
+    if (readStatus.code !== 200) {
+      throw new Error(`updateFact read failed: ${readStatus.code} ${readStatus.detail}`);
+    }
+
+    const existingData = await record.data.json() as FactData;
+    const existingTags = record.tags as TagRecord | undefined;
+
+    const newData: FactData = {
+      content : updates.content ?? existingData.content,
+      context : updates.context ?? existingData.context,
+    };
+
+    const newTags: Record<string, string | number> = {
+      category : existingTags?.category as string,
+      source   : existingTags?.source as string,
+    };
+    if (updates.confidence !== undefined) {
+      newTags.confidence = updates.confidence;
+    } else if (existingTags?.confidence !== undefined) {
+      newTags.confidence = existingTags.confidence as number;
+    }
+    if (updates.status !== undefined) {
+      newTags.status = updates.status;
+    } else if (existingTags?.status !== undefined) {
+      newTags.status = existingTags.status as string;
+    }
+    if (existingTags?.collection !== undefined) {
+      newTags.collection = existingTags.collection as string;
+    }
+
+    const { status, record: updated } = await record.update({
+      data       : newData,
+      tags       : newTags,
+      encryption : true,
+    });
+
+    if (status.code !== 202) {
+      throw new Error(`updateFact failed: ${status.code} ${status.detail}`);
+    }
+
+    return { id: updated.id, contextId: updated.contextId, status };
+  }
+
+  async supersedeFact(oldRecordId: string, newContent: string, opts?: {
+    category? : string;
+    source? : string;
+    reason? : string;
+    confidence? : number;
+    collection? : string;
+  }): Promise<RecordResult> {
+    await this.ensureConfigured();
+    // 1. Read the old fact to get its tags
+    const { status: readStatus, record: oldRecord } = await this.typed.records.read('fact', {
+      filter     : { recordId: oldRecordId },
+      encryption : true,
+    });
+
+    if (readStatus.code !== 200) {
+      throw new Error(`supersedeFact read failed: ${readStatus.code} ${readStatus.detail}`);
+    }
+
+    const oldTags = oldRecord.tags as TagRecord | undefined;
+
+    // 2. Create a new fact (inheriting category/source unless overridden)
+    const newTags: Record<string, string | number> = {
+      category : (opts?.category ?? oldTags?.category) as string,
+      source   : (opts?.source ?? oldTags?.source) as string,
+      status   : 'active',
+    };
+    if (opts?.confidence !== undefined) { newTags.confidence = opts.confidence; }
+    if (opts?.collection !== undefined) {
+      newTags.collection = opts.collection;
+    } else if (oldTags?.collection !== undefined) {
+      newTags.collection = oldTags.collection as string;
+    }
+
+    const { status: createStatus, record: newRecord } = await this.typed.records.create('fact', {
+      data       : { content: newContent },
+      tags       : newTags,
+      encryption : true,
+    });
+
+    if (createStatus.code !== 202) {
+      throw new Error(`supersedeFact create failed: ${createStatus.code} ${createStatus.detail}`);
+    }
+
+    // 3. Write a supersession sub-record on the old fact
+    const { status: supersessionStatus } = await this.typed.records.create('fact/supersession', {
+      data            : { reason: opts?.reason },
+      tags            : { supersededBy: newRecord.id },
+      parentContextId : oldRecord.contextId,
+    });
+
+    if (supersessionStatus.code !== 202) {
+      throw new Error(`supersedeFact supersession failed: ${supersessionStatus.code} ${supersessionStatus.detail}`);
+    }
+
+    // 4. Update the old fact's status tag to 'superseded'
+    const oldData = await oldRecord.data.json() as FactData;
+    const updateTags: Record<string, string | number> = {
+      category : oldTags?.category as string,
+      source   : oldTags?.source as string,
+      status   : 'superseded',
+    };
+    if (oldTags?.confidence !== undefined) { updateTags.confidence = oldTags.confidence as number; }
+    if (oldTags?.collection !== undefined) { updateTags.collection = oldTags.collection as string; }
+
+    const { status: updateStatus } = await oldRecord.update({
+      data       : oldData,
+      tags       : updateTags,
+      encryption : true,
+    });
+
+    if (updateStatus.code !== 202) {
+      throw new Error(`supersedeFact update old failed: ${updateStatus.code} ${updateStatus.detail}`);
+    }
+
+    // 5. Return the new fact's RecordResult
+    return { id: newRecord.id, contextId: newRecord.contextId, status: createStatus };
+  }
+
+  async deleteFact(recordId: string): Promise<void> {
+    await this.ensureConfigured();
+    const { status } = await this.typed.records.delete('fact', { recordId });
+
+    if (status.code !== 202) {
+      throw new Error(`deleteFact failed: ${status.code} ${status.detail}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Preferences
+  // -------------------------------------------------------------------------
+
+  async addPreference(content: string, domain: string, opts?: {
+    context? : string;
+    collection? : string;
+  }): Promise<RecordResult> {
+    await this.ensureConfigured();
+    const tags: Record<string, string> = { domain };
+    if (opts?.collection !== undefined) { tags.collection = opts.collection; }
+
+    const { status, record } = await this.typed.records.create('preference', {
+      data       : { content, context: opts?.context },
+      tags,
+      encryption : true,
+    });
+
+    if (status.code !== 202) {
+      throw new Error(`addPreference failed: ${status.code} ${status.detail}`);
+    }
+
+    return { id: record.id, contextId: record.contextId, status };
+  }
+
+  async listPreferences(
+    filters?: PreferenceFilters, pagination?: PaginationOptions,
+  ): Promise<ListResult<PreferenceRecord>> {
+    await this.ensureConfigured();
+    const tags: Record<string, string> = {};
+    if (filters?.domain !== undefined) { tags.domain = filters.domain; }
+    if (filters?.collection !== undefined) { tags.collection = filters.collection; }
+
+    const { status, records, cursor } = await this.typed.records.query('preference', {
+      filter     : Object.keys(tags).length > 0 ? { tags } : undefined,
+      dateSort   : DateSort.CreatedDescending,
+      pagination,
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`listPreferences failed: ${status.code} ${status.detail}`);
+    }
+
+    const results: PreferenceRecord[] = [];
+    for (const record of records) {
+      const data = await record.data.json() as PreferenceData;
+      const rTags = record.tags as TagRecord | undefined;
+      results.push({
+        id        : record.id,
+        contextId : record.contextId,
+        data,
+        tags      : {
+          domain     : rTags?.domain as string,
+          collection : rTags?.collection as string | undefined,
+        },
+        dateCreated: record.dateCreated,
+      });
+    }
+
+    return { records: results, cursor };
+  }
+
+  async deletePreference(recordId: string): Promise<void> {
+    await this.ensureConfigured();
+    const { status } = await this.typed.records.delete('preference', { recordId });
+
+    if (status.code !== 202) {
+      throw new Error(`deletePreference failed: ${status.code} ${status.detail}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Relationships
+  // -------------------------------------------------------------------------
+
+  async addRelationship(name: string, type: string, opts?: {
+    notes? : string;
+    collection? : string;
+  }): Promise<RecordResult> {
+    await this.ensureConfigured();
+    const tags: Record<string, string> = { name, type };
+    if (opts?.collection !== undefined) { tags.collection = opts.collection; }
+
+    const { status, record } = await this.typed.records.create('relationship', {
+      data       : { name, notes: opts?.notes },
+      tags,
+      encryption : true,
+    });
+
+    if (status.code !== 202) {
+      throw new Error(`addRelationship failed: ${status.code} ${status.detail}`);
+    }
+
+    return { id: record.id, contextId: record.contextId, status };
+  }
+
+  async listRelationships(
+    filters?: RelationshipFilters, pagination?: PaginationOptions,
+  ): Promise<ListResult<RelationshipRecord>> {
+    await this.ensureConfigured();
+    const tags: Record<string, string> = {};
+    if (filters?.name !== undefined) { tags.name = filters.name; }
+    if (filters?.type !== undefined) { tags.type = filters.type; }
+    if (filters?.collection !== undefined) { tags.collection = filters.collection; }
+
+    const { status, records, cursor } = await this.typed.records.query('relationship', {
+      filter     : Object.keys(tags).length > 0 ? { tags } : undefined,
+      dateSort   : DateSort.CreatedDescending,
+      pagination,
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`listRelationships failed: ${status.code} ${status.detail}`);
+    }
+
+    const results: RelationshipRecord[] = [];
+    for (const record of records) {
+      const data = await record.data.json() as RelationshipData;
+      const rTags = record.tags as TagRecord | undefined;
+      results.push({
+        id        : record.id,
+        contextId : record.contextId,
+        data,
+        tags      : {
+          name       : rTags?.name as string,
+          type       : rTags?.type as string,
+          collection : rTags?.collection as string | undefined,
+        },
+        dateCreated: record.dateCreated,
+      });
+    }
+
+    return { records: results, cursor };
+  }
+
+  async deleteRelationship(recordId: string): Promise<void> {
+    await this.ensureConfigured();
+    const { status } = await this.typed.records.delete('relationship', { recordId });
+
+    if (status.code !== 202) {
+      throw new Error(`deleteRelationship failed: ${status.code} ${status.detail}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,16 @@ export type { DependencyData, NoteData, StatusChangeData, TaskData } from './pro
 
 export { AuditProtocol } from './protocols/audit.js';
 export type { ActionLogData } from './protocols/audit.js';
+
+export { MemoryStore } from './core/memory-store.js';
+export type {
+  FactFilters,
+  FactRecord,
+  ListResult,
+  PaginationOptions,
+  PreferenceFilters,
+  PreferenceRecord,
+  RecordResult,
+  RelationshipFilters,
+  RelationshipRecord,
+} from './core/memory-store.js';

--- a/tests/core/memory-store.spec.ts
+++ b/tests/core/memory-store.spec.ts
@@ -1,0 +1,245 @@
+import { rmSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { MemoryProtocol } from '../../src/protocols/memory.js';
+import { MemoryStore } from '../../src/core/memory-store.js';
+
+const DATA_PATH = '__TESTDATA__/memory-store';
+
+describe('MemoryStore', () => {
+  let store: MemoryStore;
+  let web5: Web5;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test' });
+    await agent.start({ password: 'test' });
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Test' },
+        didOptions : {
+          verificationMethods: [
+            {
+              algorithm : 'Ed25519',
+              id        : 'sig',
+              purposes  : ['assertionMethod', 'authentication'],
+            },
+            {
+              algorithm : 'X25519',
+              id        : 'enc',
+              purposes  : ['keyAgreement'],
+            },
+          ],
+        },
+      });
+    }
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    web5 = result.web5;
+
+    // Configure protocol with encryption
+    const typed = web5.using(MemoryProtocol);
+    await typed.configure({ encryption: true });
+
+    store = new MemoryStore(web5);
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Facts
+  // -------------------------------------------------------------------------
+
+  describe('facts', () => {
+    it('addFact creates a fact and returns RecordResult with id', async () => {
+      const result = await store.addFact('User likes cats', 'personal', 'user');
+      expect(result.id).toBeDefined();
+      expect(typeof result.id).toBe('string');
+      expect(result.status.code).toBe(202);
+    });
+
+    it('getFact retrieves a fact by ID with correct data and tags', async () => {
+      const created = await store.addFact('User likes dogs', 'personal', 'user', {
+        confidence: 0.9,
+      });
+      const fact = await store.getFact(created.id);
+      expect(fact.id).toBe(created.id);
+      expect(fact.data.content).toBe('User likes dogs');
+      expect(fact.tags.category).toBe('personal');
+      expect(fact.tags.source).toBe('user');
+      expect(fact.tags.confidence).toBe(0.9);
+      expect(fact.tags.status).toBe('active');
+      expect(fact.dateCreated).toBeDefined();
+    });
+
+    it('listFacts returns all facts', async () => {
+      const { records } = await store.listFacts();
+      expect(records.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('listFacts filters by category', async () => {
+      await store.addFact('Work meeting at 9', 'work', 'agent');
+      const { records } = await store.listFacts({ category: 'work' });
+      expect(records.length).toBeGreaterThanOrEqual(1);
+      for (const r of records) {
+        expect(r.tags.category).toBe('work');
+      }
+    });
+
+    it('listFacts supports pagination', async () => {
+      // Create 5 facts with a unique category for isolation
+      for (let i = 0; i < 5; i++) {
+        await store.addFact(`Paginated fact ${i}`, 'pagination-test', 'user');
+      }
+
+      const page1 = await store.listFacts(
+        { category: 'pagination-test' },
+        { limit: 2 },
+      );
+      expect(page1.records.length).toBe(2);
+      expect(page1.cursor).toBeDefined();
+
+      const page2 = await store.listFacts(
+        { category: 'pagination-test' },
+        { limit: 2, cursor: page1.cursor },
+      );
+      expect(page2.records.length).toBe(2);
+      expect(page2.cursor).toBeDefined();
+
+      const page3 = await store.listFacts(
+        { category: 'pagination-test' },
+        { limit: 2, cursor: page2.cursor },
+      );
+      expect(page3.records.length).toBe(1);
+    });
+
+    it('updateFact updates content', async () => {
+      const created = await store.addFact('Original content', 'personal', 'user');
+      const updated = await store.updateFact(created.id, {
+        content: 'Updated content',
+      });
+      expect(updated.status.code).toBe(202);
+
+      const fact = await store.getFact(created.id);
+      expect(fact.data.content).toBe('Updated content');
+      expect(fact.tags.category).toBe('personal');
+    });
+
+    it('supersedeFact creates new fact and marks old as superseded', async () => {
+      const old = await store.addFact('Old fact', 'personal', 'user');
+      const result = await store.supersedeFact(old.id, 'New fact', {
+        reason: 'Updated info',
+      });
+
+      expect(result.id).toBeDefined();
+      expect(result.id).not.toBe(old.id);
+      expect(result.status.code).toBe(202);
+
+      // New fact should be active
+      const newFact = await store.getFact(result.id);
+      expect(newFact.data.content).toBe('New fact');
+      expect(newFact.tags.status).toBe('active');
+
+      // Old fact should be superseded
+      const oldFact = await store.getFact(old.id);
+      expect(oldFact.tags.status).toBe('superseded');
+    });
+
+    it('supersedeFact inherits category/source from old fact', async () => {
+      const old = await store.addFact('Original', 'health', 'agent');
+      const result = await store.supersedeFact(old.id, 'Replacement');
+
+      const newFact = await store.getFact(result.id);
+      expect(newFact.tags.category).toBe('health');
+      expect(newFact.tags.source).toBe('agent');
+    });
+
+    it('deleteFact deletes a fact', async () => {
+      const created = await store.addFact('To be deleted', 'personal', 'user');
+      await store.deleteFact(created.id);
+
+      try {
+        await store.getFact(created.id);
+        // If we get here, the read succeeded — unexpected
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Preferences
+  // -------------------------------------------------------------------------
+
+  describe('preferences', () => {
+    it('addPreference creates a preference', async () => {
+      const result = await store.addPreference('Dark mode preferred', 'ui');
+      expect(result.id).toBeDefined();
+      expect(result.status.code).toBe(202);
+    });
+
+    it('listPreferences returns preferences filtered by domain', async () => {
+      await store.addPreference('Large font', 'accessibility');
+      const { records } = await store.listPreferences({ domain: 'accessibility' });
+      expect(records.length).toBeGreaterThanOrEqual(1);
+      for (const r of records) {
+        expect(r.tags.domain).toBe('accessibility');
+      }
+    });
+
+    it('deletePreference deletes a preference', async () => {
+      const created = await store.addPreference('To delete', 'temp');
+      await store.deletePreference(created.id);
+
+      // Verify it's gone by listing with a unique domain
+      const { records } = await store.listPreferences({ domain: 'temp' });
+      const found = records.find(r => r.id === created.id);
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Relationships
+  // -------------------------------------------------------------------------
+
+  describe('relationships', () => {
+    it('addRelationship creates a relationship', async () => {
+      const result = await store.addRelationship('Alice', 'person', {
+        notes: 'Close friend',
+      });
+      expect(result.id).toBeDefined();
+      expect(result.status.code).toBe(202);
+    });
+
+    it('listRelationships filters by type', async () => {
+      await store.addRelationship('Acme Corp', 'org');
+      const { records } = await store.listRelationships({ type: 'org' });
+      expect(records.length).toBeGreaterThanOrEqual(1);
+      for (const r of records) {
+        expect(r.tags.type).toBe('org');
+      }
+    });
+
+    it('deleteRelationship deletes a relationship', async () => {
+      const created = await store.addRelationship('Bob', 'person');
+      await store.deleteRelationship(created.id);
+
+      const { records } = await store.listRelationships({ name: 'Bob' });
+      const found = records.find(r => r.id === created.id);
+      expect(found).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `MemoryStore` class in `src/core/memory-store.ts` that wraps the TypedWeb5 API for the `MemoryProtocol`, providing typed CRUD methods for facts, preferences, and relationships.
- All encrypted record types (fact, preference, relationship) are created and read with `encryption: true`, with lazy protocol configuration via `ensureConfigured()`.
- Adds 15 integration tests in `tests/core/memory-store.spec.ts` using a real DWN agent with `did:dht` (Ed25519 + X25519 keys) for full encryption support.

### Methods implemented

**Facts**: `addFact`, `getFact`, `listFacts` (with filters + pagination), `updateFact`, `supersedeFact` (creates new fact, writes supersession sub-record, marks old as superseded), `deleteFact`

**Preferences**: `addPreference`, `listPreferences` (with filters + pagination), `deletePreference`

**Relationships**: `addRelationship`, `listRelationships` (with filters + pagination), `deleteRelationship`

### Checks

- `bun run build` -- zero TypeScript errors
- `bun run lint` -- zero ESLint warnings/errors
- `bun test .spec.ts` -- 57 tests pass (15 new + 42 existing)

Closes #5