### PR TITLE
feat: DWN task store (task graph CRUD)

### DIFF
--- a/src/core/task-store.ts
+++ b/src/core/task-store.ts
@@ -1,0 +1,441 @@
+import type { DwnPaginationCursor } from '@enbox/agent';
+import type { Web5 } from '@enbox/api';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+
+import { TaskGraphProtocol } from '../protocols/task-graph.js';
+import type { DependencyData, NoteData, StatusChangeData, TaskData } from '../protocols/task-graph.js';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export type TaskResult = {
+  id : string;
+  contextId : string | undefined;
+  status : { code: number; detail: string };
+};
+
+export type TaskRecord = {
+  id : string;
+  contextId : string | undefined;
+  data : TaskData;
+  tags : {
+    status : string;
+    priority : string;
+    type? : string;
+    assignee? : string;
+    collection? : string;
+  };
+  dateCreated : string;
+};
+
+export type TaskDetail = TaskRecord & {
+  subtasks : TaskRecord[];
+  dependencies : DependencyRecord[];
+  statusHistory : StatusChangeRecord[];
+  notes : NoteRecord[];
+};
+
+export type DependencyRecord = {
+  id : string;
+  data : DependencyData;
+  tags : { type: string; targetId: string };
+};
+
+export type StatusChangeRecord = {
+  id : string;
+  data : StatusChangeData;
+  tags : { from: string; to: string; reason?: string };
+  dateCreated : string;
+};
+
+export type NoteRecord = {
+  id : string;
+  data : NoteData;
+  dateCreated : string;
+};
+
+export type TaskFilters = {
+  status? : string;
+  priority? : string;
+  type? : string;
+  assignee? : string;
+  collection? : string;
+};
+
+export type TaskListResult = {
+  records : TaskRecord[];
+  cursor? : DwnPaginationCursor;
+};
+
+export type PaginationOptions = {
+  limit? : number;
+  cursor? : DwnPaginationCursor;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type TagFilter = Record<string, string>;
+
+function buildTagFilter(filters?: TaskFilters): TagFilter | undefined {
+  if (!filters) {
+    return undefined;
+  }
+  const tags: TagFilter = {};
+  if (filters.status !== undefined) { tags.status = filters.status; }
+  if (filters.priority !== undefined) { tags.priority = filters.priority; }
+  if (filters.type !== undefined) { tags.type = filters.type; }
+  if (filters.assignee !== undefined) { tags.assignee = filters.assignee; }
+  if (filters.collection !== undefined) { tags.collection = filters.collection; }
+  return Object.keys(tags).length > 0 ? tags : undefined;
+}
+
+function extractTaskTags(
+  raw: Record<string, unknown> | undefined,
+): TaskRecord['tags'] {
+  const t = raw ?? {};
+  return {
+    status   : t.status as string,
+    priority : t.priority as string,
+    ...(t.type !== undefined ? { type: t.type as string } : {}),
+    ...(t.assignee !== undefined ? { assignee: t.assignee as string } : {}),
+    ...(t.collection !== undefined ? { collection: t.collection as string } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TaskStore
+// ---------------------------------------------------------------------------
+
+export class TaskStore {
+  private readonly typed;
+  private configurePromise: Promise<void> | undefined;
+
+  constructor(private readonly web5: Web5) {
+    this.typed = web5.using(TaskGraphProtocol);
+  }
+
+  private ensureConfigured(): Promise<void> {
+    if (!this.configurePromise) {
+      this.configurePromise = this.typed.configure({ encryption: true }).then(() => undefined);
+    }
+    return this.configurePromise;
+  }
+
+  // -----------------------------------------------------------------------
+  // Task CRUD
+  // -----------------------------------------------------------------------
+
+  async createTask(
+    title: string,
+    priority: string,
+    opts?: {
+      description? : string;
+      type? : string;
+      assignee? : string;
+      collection? : string;
+    },
+  ): Promise<TaskResult> {
+    await this.ensureConfigured();
+
+    const tags: Record<string, string> = { status: 'open', priority };
+    if (opts?.type !== undefined) { tags.type = opts.type; }
+    if (opts?.assignee !== undefined) { tags.assignee = opts.assignee; }
+    if (opts?.collection !== undefined) { tags.collection = opts.collection; }
+
+    const data: TaskData = { title };
+    if (opts?.description !== undefined) { data.description = opts.description; }
+
+    const { record, status } = await this.typed.records.create('task', {
+      data,
+      tags,
+      encryption: true,
+    });
+
+    return { id: record.id, contextId: record.contextId, status };
+  }
+
+  async createSubtask(
+    parentContextId: string,
+    title: string,
+    priority: string,
+    opts?: {
+      description? : string;
+      type? : string;
+      assignee? : string;
+      collection? : string;
+    },
+  ): Promise<TaskResult> {
+    await this.ensureConfigured();
+
+    const tags: Record<string, string> = { status: 'open', priority };
+    if (opts?.type !== undefined) { tags.type = opts.type; }
+    if (opts?.assignee !== undefined) { tags.assignee = opts.assignee; }
+    if (opts?.collection !== undefined) { tags.collection = opts.collection; }
+
+    const data: TaskData = { title };
+    if (opts?.description !== undefined) { data.description = opts.description; }
+
+    const { record, status } = await this.typed.records.create('task/task', {
+      data,
+      tags,
+      parentContextId,
+      encryption: true,
+    });
+
+    return { id: record.id, contextId: record.contextId, status };
+  }
+
+  async updateTask(
+    recordId: string,
+    updates: {
+      title? : string;
+      description? : string;
+      status? : string;
+      priority? : string;
+      type? : string;
+      assignee? : string;
+    },
+  ): Promise<TaskResult> {
+    await this.ensureConfigured();
+
+    const { record: existing } = await this.typed.records.read('task', {
+      filter     : { recordId },
+      encryption : true,
+    });
+
+    const currentData = await existing.data.json();
+    const currentTags = (existing.tags ?? {}) as Record<string, string>;
+
+    const newData: TaskData = {
+      title       : updates.title ?? currentData.title,
+      description : updates.description ?? currentData.description,
+    };
+
+    const newTags: Record<string, string> = { ...currentTags };
+    if (updates.status !== undefined) { newTags.status = updates.status; }
+    if (updates.priority !== undefined) { newTags.priority = updates.priority; }
+    if (updates.type !== undefined) { newTags.type = updates.type; }
+    if (updates.assignee !== undefined) { newTags.assignee = updates.assignee; }
+
+    const { status } = await existing.update({ data: newData, tags: newTags });
+
+    // If status changed, write a statusChange sub-record
+    if (updates.status !== undefined && updates.status !== currentTags.status) {
+      const scTags: Record<string, string> = {
+        from : currentTags.status,
+        to   : updates.status,
+      };
+
+      await this.typed.records.create('task/statusChange', {
+        data            : {} as StatusChangeData,
+        tags            : scTags,
+        parentContextId : existing.contextId!,
+      });
+    }
+
+    return { id: existing.id, contextId: existing.contextId, status };
+  }
+
+  async claimTask(recordId: string, assignee: string): Promise<TaskResult> {
+    await this.ensureConfigured();
+
+    const { record: existing } = await this.typed.records.read('task', {
+      filter     : { recordId },
+      encryption : true,
+    });
+
+    const currentData = await existing.data.json();
+    const currentTags = (existing.tags ?? {}) as Record<string, string>;
+    const previousStatus = currentTags.status;
+
+    const newTags: Record<string, string> = {
+      ...currentTags,
+      status: 'in_progress',
+      assignee,
+    };
+
+    const { status } = await existing.update({ data: currentData, tags: newTags });
+
+    // Write statusChange record
+    if (previousStatus !== 'in_progress') {
+      const scTags: Record<string, string> = {
+        from : previousStatus,
+        to   : 'in_progress',
+      };
+
+      await this.typed.records.create('task/statusChange', {
+        data            : {} as StatusChangeData,
+        tags            : scTags,
+        parentContextId : existing.contextId!,
+      });
+    }
+
+    return { id: existing.id, contextId: existing.contextId, status };
+  }
+
+  async addDependency(
+    taskContextId: string,
+    dependsOnTaskId: string,
+    type: string,
+    opts?: { description?: string },
+  ): Promise<void> {
+    await this.ensureConfigured();
+
+    const data: DependencyData = {};
+    if (opts?.description !== undefined) { data.description = opts.description; }
+
+    await this.typed.records.create('task/dependency', {
+      data,
+      tags            : { type, targetId: dependsOnTaskId },
+      parentContextId : taskContextId,
+    });
+  }
+
+  async addNote(taskContextId: string, content: string): Promise<void> {
+    await this.ensureConfigured();
+
+    await this.typed.records.create('task/note', {
+      data            : { content } as NoteData,
+      parentContextId : taskContextId,
+    });
+  }
+
+  async getTask(recordId: string): Promise<TaskDetail> {
+    await this.ensureConfigured();
+
+    const { record } = await this.typed.records.read('task', {
+      filter     : { recordId },
+      encryption : true,
+    });
+
+    const data = await record.data.json();
+    const tags = extractTaskTags(record.tags as Record<string, unknown> | undefined);
+
+    // Query nested records in parallel
+    const [subtaskRes, depRes, scRes, noteRes] = await Promise.all([
+      this.typed.records.query('task/task', {
+        filter     : { contextId: record.contextId },
+        dateSort   : DateSort.CreatedDescending,
+        encryption : true,
+      }),
+      this.typed.records.query('task/dependency', {
+        filter   : { contextId: record.contextId },
+        dateSort : DateSort.CreatedDescending,
+      }),
+      this.typed.records.query('task/statusChange', {
+        filter   : { contextId: record.contextId },
+        dateSort : DateSort.CreatedDescending,
+      }),
+      this.typed.records.query('task/note', {
+        filter   : { contextId: record.contextId },
+        dateSort : DateSort.CreatedDescending,
+      }),
+    ]);
+
+    const subtasks: TaskRecord[] = await Promise.all(
+      subtaskRes.records.map(async (r) => {
+        const d = await r.data.json();
+        return {
+          id          : r.id,
+          contextId   : r.contextId,
+          data        : d,
+          tags        : extractTaskTags(r.tags as Record<string, unknown> | undefined),
+          dateCreated : r.dateCreated,
+        };
+      }),
+    );
+
+    const dependencies: DependencyRecord[] = await Promise.all(
+      depRes.records.map(async (r) => {
+        const d = await r.data.json();
+        const rt = (r.tags ?? {}) as Record<string, string>;
+        return {
+          id   : r.id,
+          data : d,
+          tags : { type: rt.type, targetId: rt.targetId },
+        };
+      }),
+    );
+
+    const statusHistory: StatusChangeRecord[] = await Promise.all(
+      scRes.records.map(async (r) => {
+        const d = await r.data.json();
+        const rt = (r.tags ?? {}) as Record<string, string>;
+        return {
+          id   : r.id,
+          data : d,
+          tags : {
+            from : rt.from,
+            to   : rt.to,
+            ...(rt.reason !== undefined ? { reason: rt.reason } : {}),
+          },
+          dateCreated: r.dateCreated,
+        };
+      }),
+    );
+
+    const notes: NoteRecord[] = await Promise.all(
+      noteRes.records.map(async (r) => {
+        const d = await r.data.json();
+        return {
+          id          : r.id,
+          data        : d,
+          dateCreated : r.dateCreated,
+        };
+      }),
+    );
+
+    return {
+      id          : record.id,
+      contextId   : record.contextId,
+      data,
+      tags,
+      dateCreated : record.dateCreated,
+      subtasks,
+      dependencies,
+      statusHistory,
+      notes,
+    };
+  }
+
+  async listTasks(
+    filters?: TaskFilters,
+    pagination?: PaginationOptions,
+  ): Promise<TaskListResult> {
+    await this.ensureConfigured();
+
+    const tagFilter = buildTagFilter(filters);
+
+    const { records, cursor } = await this.typed.records.query('task', {
+      filter     : tagFilter ? { tags: tagFilter } : undefined,
+      dateSort   : DateSort.CreatedDescending,
+      encryption : true,
+      ...(pagination ? { pagination: { limit: pagination.limit, cursor: pagination.cursor } } : {}),
+    });
+
+    const mapped: TaskRecord[] = await Promise.all(
+      records.map(async (r) => {
+        const d = await r.data.json();
+        return {
+          id          : r.id,
+          contextId   : r.contextId,
+          data        : d,
+          tags        : extractTaskTags(r.tags as Record<string, unknown> | undefined),
+          dateCreated : r.dateCreated,
+        };
+      }),
+    );
+
+    return { records: mapped, cursor };
+  }
+
+  async deleteTask(recordId: string): Promise<void> {
+    await this.ensureConfigured();
+
+    await this.typed.records.delete('task', { recordId });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,15 @@ export type {
   RelationshipFilters,
   RelationshipRecord,
 } from './core/memory-store.js';
+
+export { TaskStore } from './core/task-store.js';
+export type {
+  DependencyRecord,
+  NoteRecord,
+  StatusChangeRecord,
+  TaskDetail,
+  TaskFilters,
+  TaskListResult,
+  TaskRecord,
+  TaskResult,
+} from './core/task-store.js';

--- a/tests/core/task-store.spec.ts
+++ b/tests/core/task-store.spec.ts
@@ -1,0 +1,241 @@
+import { rmSync } from 'node:fs';
+
+import { TaskStore } from '../../src/core/task-store.js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+const DATA_PATH = '__TESTDATA__/task-store';
+
+describe('TaskStore', () => {
+  let store: TaskStore;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test' });
+    await agent.start({ password: 'test' });
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Test' },
+        didOptions : {
+          verificationMethods: [
+            { algorithm: 'Ed25519', purposes: ['authentication', 'assertionMethod'] },
+            { algorithm: 'X25519', purposes: ['keyAgreement'] },
+          ],
+        },
+      });
+    }
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    store = new TaskStore(result.web5);
+  }, 30_000);
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // Task CRUD
+  // -----------------------------------------------------------------------
+
+  it('createTask creates a task with status open and returns id', async () => {
+    const result = await store.createTask('My first task', 'p1', {
+      description : 'A test task',
+      type        : 'feature',
+    });
+
+    expect(result.id).toBeDefined();
+    expect(typeof result.id).toBe('string');
+    expect(result.contextId).toBeDefined();
+    expect(result.status.code).toBe(202);
+  });
+
+  it('getTask retrieves full task detail with empty subtasks/deps/notes', async () => {
+    const created = await store.createTask('Detail task', 'p2');
+    const detail = await store.getTask(created.id);
+
+    expect(detail.id).toBe(created.id);
+    expect(detail.data.title).toBe('Detail task');
+    expect(detail.tags.status).toBe('open');
+    expect(detail.tags.priority).toBe('p2');
+    expect(detail.subtasks).toEqual([]);
+    expect(detail.dependencies).toEqual([]);
+    expect(detail.statusHistory).toEqual([]);
+    expect(detail.notes).toEqual([]);
+  });
+
+  it('listTasks returns all tasks', async () => {
+    const list = await store.listTasks();
+    expect(list.records.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('listTasks filters by status', async () => {
+    const list = await store.listTasks({ status: 'open' });
+    for (const r of list.records) {
+      expect(r.tags.status).toBe('open');
+    }
+  });
+
+  it('listTasks filters by priority', async () => {
+    await store.createTask('P0 task', 'p0');
+    const list = await store.listTasks({ priority: 'p0' });
+    expect(list.records.length).toBeGreaterThanOrEqual(1);
+    for (const r of list.records) {
+      expect(r.tags.priority).toBe('p0');
+    }
+  });
+
+  it('listTasks supports pagination', async () => {
+    const page1 = await store.listTasks(undefined, { limit: 1 });
+    expect(page1.records.length).toBe(1);
+    expect(page1.cursor).toBeDefined();
+
+    const page2 = await store.listTasks(undefined, { limit: 1, cursor: page1.cursor });
+    expect(page2.records.length).toBe(1);
+    expect(page2.records[0].id).not.toBe(page1.records[0].id);
+  });
+
+  it('updateTask updates title and priority', async () => {
+    const created = await store.createTask('Original title', 'p3');
+    await store.updateTask(created.id, { title: 'Updated title', priority: 'p1' });
+
+    const detail = await store.getTask(created.id);
+    expect(detail.data.title).toBe('Updated title');
+    expect(detail.tags.priority).toBe('p1');
+  });
+
+  it('updateTask with status change creates statusChange record', async () => {
+    const created = await store.createTask('Status test', 'p2');
+    await store.updateTask(created.id, { status: 'in_progress' });
+
+    const detail = await store.getTask(created.id);
+    expect(detail.tags.status).toBe('in_progress');
+    expect(detail.statusHistory.length).toBe(1);
+    expect(detail.statusHistory[0].tags.from).toBe('open');
+    expect(detail.statusHistory[0].tags.to).toBe('in_progress');
+  });
+
+  it('deleteTask deletes a task', async () => {
+    const created = await store.createTask('To delete', 'p4');
+    await store.deleteTask(created.id);
+
+    // After deletion, listing should not include it
+    const list = await store.listTasks();
+    const ids = list.records.map(r => r.id);
+    expect(ids).not.toContain(created.id);
+  });
+
+  // -----------------------------------------------------------------------
+  // Subtasks
+  // -----------------------------------------------------------------------
+
+  it('createSubtask creates a subtask nested under parent', async () => {
+    const parent = await store.createTask('Parent task', 'p1');
+    const sub = await store.createSubtask(parent.contextId!, 'Child task', 'p2');
+
+    expect(sub.id).toBeDefined();
+    expect(sub.contextId).toBeDefined();
+    expect(sub.status.code).toBe(202);
+  });
+
+  it('getTask on parent includes subtask in detail', async () => {
+    const parent = await store.createTask('Parent with sub', 'p1');
+    await store.createSubtask(parent.contextId!, 'Sub A', 'p2');
+
+    const detail = await store.getTask(parent.id);
+    expect(detail.subtasks.length).toBe(1);
+    expect(detail.subtasks[0].data.title).toBe('Sub A');
+    expect(detail.subtasks[0].tags.status).toBe('open');
+  });
+
+  // -----------------------------------------------------------------------
+  // Dependencies
+  // -----------------------------------------------------------------------
+
+  it('addDependency creates a dependency record', async () => {
+    const taskA = await store.createTask('Task A', 'p1');
+    const taskB = await store.createTask('Task B', 'p1');
+
+    await store.addDependency(taskA.contextId!, taskB.id, 'blocks', {
+      description: 'A blocks B',
+    });
+
+    const detail = await store.getTask(taskA.id);
+    expect(detail.dependencies.length).toBe(1);
+    expect(detail.dependencies[0].tags.type).toBe('blocks');
+    expect(detail.dependencies[0].tags.targetId).toBe(taskB.id);
+  });
+
+  it('getTask includes dependencies in detail', async () => {
+    const task = await store.createTask('Dep parent', 'p1');
+    const other = await store.createTask('Dep target', 'p2');
+    await store.addDependency(task.contextId!, other.id, 'relates_to');
+
+    const detail = await store.getTask(task.id);
+    expect(detail.dependencies.length).toBe(1);
+    expect(detail.dependencies[0].tags.type).toBe('relates_to');
+  });
+
+  // -----------------------------------------------------------------------
+  // Status management
+  // -----------------------------------------------------------------------
+
+  it('claimTask sets assignee and transitions to in_progress', async () => {
+    const created = await store.createTask('Claim me', 'p1');
+    await store.claimTask(created.id, 'did:example:alice');
+
+    const detail = await store.getTask(created.id);
+    expect(detail.tags.status).toBe('in_progress');
+    expect(detail.tags.assignee).toBe('did:example:alice');
+  });
+
+  it('claimTask creates a statusChange record', async () => {
+    const created = await store.createTask('Claim with history', 'p2');
+    await store.claimTask(created.id, 'did:example:bob');
+
+    const detail = await store.getTask(created.id);
+    expect(detail.statusHistory.length).toBe(1);
+    expect(detail.statusHistory[0].tags.from).toBe('open');
+    expect(detail.statusHistory[0].tags.to).toBe('in_progress');
+  });
+
+  it('getTask includes status history', async () => {
+    const created = await store.createTask('History task', 'p1');
+    await store.updateTask(created.id, { status: 'in_progress' });
+    await store.updateTask(created.id, { status: 'closed' });
+
+    const detail = await store.getTask(created.id);
+    expect(detail.statusHistory.length).toBe(2);
+  });
+
+  // -----------------------------------------------------------------------
+  // Notes
+  // -----------------------------------------------------------------------
+
+  it('addNote creates a note on a task', async () => {
+    const task = await store.createTask('Note task', 'p1');
+    await store.addNote(task.contextId!, 'This is a note');
+
+    const detail = await store.getTask(task.id);
+    expect(detail.notes.length).toBe(1);
+    expect(detail.notes[0].data.content).toBe('This is a note');
+  });
+
+  it('getTask includes notes in detail', async () => {
+    const task = await store.createTask('Multi note', 'p1');
+    await store.addNote(task.contextId!, 'Note 1');
+    await store.addNote(task.contextId!, 'Note 2');
+
+    const detail = await store.getTask(task.id);
+    expect(detail.notes.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the task graph CRUD layer (`TaskStore`) that wraps the `@enbox/api` TypedWeb5 interface for the `task-graph/v1` protocol. (Issue #6)

### `TaskStore` API

| Method | Description |
|--------|-------------|
| `createTask(title, priority, opts?)` | Create a root task (status: open) |
| `createSubtask(parentContextId, title, priority, opts?)` | Nested subtask via `task/task` path |
| `updateTask(recordId, updates)` | Update task data/tags; auto-creates `statusChange` on status transition |
| `claimTask(recordId, assignee)` | Atomic: assignee + in_progress + statusChange |
| `addDependency(taskContextId, dependsOnId, type, opts?)` | Immutable `task/dependency` record |
| `addNote(taskContextId, content)` | `task/note` record |
| `getTask(recordId)` | Full detail: subtasks, deps, status history, notes (parallel queries) |
| `listTasks(filters?, pagination?)` | Tag-based filtering + cursor pagination |
| `deleteTask(recordId)` | Delete by record ID |

### Key details
- Encryption: `task` type has `encryptionRequired: true`; uses `did:dht` with X25519 keyAgreement for encryption support
- Lazy protocol configuration via `ensureConfigured()` (idempotent)
- Status transitions automatically produce immutable `statusChange` audit records
- 9 exported types: `TaskResult`, `TaskRecord`, `TaskDetail`, `DependencyRecord`, `StatusChangeRecord`, `NoteRecord`, `TaskFilters`, `TaskListResult`, `PaginationOptions`

### Tests
18 integration tests covering all CRUD operations, subtask creation, dependency linking, status management, note creation, tag filtering, and pagination.

## Quality gates

```
bun run build   ✅ Zero TypeScript errors
bun run lint    ✅ Zero ESLint warnings/errors
bun test        ✅ 60 pass, 0 fail (2.4s)
```

Closes #6