### PR TITLE
feat: add vector sidecar with sqlite-vec + FTS5 hybrid search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,8 @@ export type { TaskTreeNode } from './core/graph.js';
 
 export type { EmbeddingConfig, EmbeddingProvider } from './sidecar/embeddings.js';
 export { createEmbeddingProvider, NoopProvider, OllamaProvider, OpenAIProvider } from './sidecar/embeddings.js';
+
+export { SidecarDatabase } from './sidecar/database.js';
+
+export { SearchIndex } from './sidecar/search.js';
+export type { IndexRecord, SearchFilters, SearchResult } from './sidecar/search.js';

--- a/src/sidecar/database.ts
+++ b/src/sidecar/database.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// SidecarDatabase — SQLite lifecycle management for the vector sidecar.
+// ---------------------------------------------------------------------------
+
+import * as sqliteVec from 'sqlite-vec';
+import { Database } from 'bun:sqlite';
+
+export class SidecarDatabase {
+  readonly db: Database;
+
+  constructor(dbPath: string, dimensions: number = 768) {
+    this.db = new Database(dbPath);
+    sqliteVec.load(this.db);
+    this.db.exec('PRAGMA journal_mode = WAL;');
+    this.createTables(dimensions);
+  }
+
+  private createTables(dimensions: number): void {
+    // Vector search (sqlite-vec)
+    // vec0 does not support IF NOT EXISTS; use try/catch for idempotency.
+    try {
+      this.db.exec(`
+        CREATE VIRTUAL TABLE memory_embeddings USING vec0(
+          embedding float[${dimensions}],
+          +record_id TEXT NOT NULL,
+          +protocol_path TEXT NOT NULL,
+          +content_preview TEXT,
+          +category TEXT,
+          +collection TEXT,
+          +updated_at TEXT NOT NULL
+        );
+      `);
+    } catch (e: unknown) {
+      // Table already exists — safe to ignore.
+      if (!(e instanceof Error) || !e.message.includes('already exists')) {
+        throw e;
+      }
+    }
+
+    // Full-text search (FTS5)
+    this.db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+        content,
+        record_id UNINDEXED,
+        protocol_path UNINDEXED,
+        category UNINDEXED,
+        collection UNINDEXED
+      );
+    `);
+
+    // Task graph cache
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS task_graph (
+        task_id TEXT NOT NULL,
+        depends_on TEXT NOT NULL,
+        dep_type TEXT NOT NULL,
+        PRIMARY KEY (task_id, depends_on)
+      );
+    `);
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS task_status (
+        task_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        priority TEXT,
+        assignee TEXT,
+        title TEXT,
+        record_id TEXT NOT NULL
+      );
+    `);
+
+    // Sync tracking
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sync_state (
+        protocol TEXT PRIMARY KEY,
+        cursor TEXT,
+        last_sync TEXT NOT NULL
+      );
+    `);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/src/sidecar/index.ts
+++ b/src/sidecar/index.ts
@@ -2,3 +2,8 @@
 
 export type { EmbeddingConfig, EmbeddingProvider } from './embeddings.js';
 export { createEmbeddingProvider, NoopProvider, OllamaProvider, OpenAIProvider } from './embeddings.js';
+
+export { SidecarDatabase } from './database.js';
+
+export { SearchIndex } from './search.js';
+export type { IndexRecord, SearchFilters, SearchResult } from './search.js';

--- a/src/sidecar/search.ts
+++ b/src/sidecar/search.ts
@@ -1,0 +1,269 @@
+// ---------------------------------------------------------------------------
+// SearchIndex — Hybrid search with RRF (Reciprocal Rank Fusion).
+// Combines sqlite-vec KNN vector search with FTS5 BM25 full-text search.
+// ---------------------------------------------------------------------------
+
+import type { Database } from 'bun:sqlite';
+
+import type { EmbeddingProvider } from './embeddings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SearchResult = {
+  recordId: string;
+  protocolPath: string;
+  content: string;
+  category?: string;
+  collection?: string;
+  score: number;
+};
+
+export type SearchFilters = {
+  protocolPath?: string;
+  category?: string;
+  collection?: string;
+};
+
+export type IndexRecord = {
+  recordId: string;
+  protocolPath: string;
+  content: string;
+  category?: string;
+  collection?: string;
+};
+
+// ---------------------------------------------------------------------------
+// SearchIndex
+// ---------------------------------------------------------------------------
+
+export class SearchIndex {
+  constructor(
+    private readonly db: Database,
+    private readonly embeddings: EmbeddingProvider,
+  ) {}
+
+  /** Upsert a record into both vector and FTS indexes. */
+  async upsert(record: IndexRecord): Promise<void> {
+    const embedding = await this.embeddings.embed(record.content);
+    const now = new Date().toISOString();
+
+    // Delete existing entries for this record_id (if updating)
+    this.db.prepare('DELETE FROM memory_embeddings WHERE record_id = ?').run(record.recordId);
+    this.db.prepare('DELETE FROM memory_fts WHERE record_id = ?').run(record.recordId);
+
+    // Insert into vec0
+    this.db.prepare(`
+      INSERT INTO memory_embeddings(embedding, record_id, protocol_path, content_preview, category, collection, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      new Float32Array(embedding),
+      record.recordId,
+      record.protocolPath,
+      record.content.substring(0, 200),
+      record.category ?? null,
+      record.collection ?? null,
+      now,
+    );
+
+    // Insert into FTS5
+    this.db.prepare(`
+      INSERT INTO memory_fts(content, record_id, protocol_path, category, collection)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      record.content,
+      record.recordId,
+      record.protocolPath,
+      record.category ?? null,
+      record.collection ?? null,
+    );
+  }
+
+  /** Remove a record from both indexes. */
+  remove(recordId: string): void {
+    this.db.prepare('DELETE FROM memory_embeddings WHERE record_id = ?').run(recordId);
+    this.db.prepare('DELETE FROM memory_fts WHERE record_id = ?').run(recordId);
+  }
+
+  /** Hybrid search: vector KNN + FTS5 BM25, merged with reciprocal rank fusion. */
+  async search(query: string, opts?: {
+    limit?: number;
+    filters?: SearchFilters;
+  }): Promise<SearchResult[]> {
+    const limit = opts?.limit ?? 10;
+    const k = 60; // RRF constant
+
+    // 1. Vector KNN search
+    const queryEmbedding = await this.embeddings.embed(query);
+    const vectorResults = this.vectorSearch(new Float32Array(queryEmbedding), limit * 2, opts?.filters);
+
+    // 2. FTS5 search
+    const ftsResults = this.ftsSearch(query, limit * 2, opts?.filters);
+
+    // 3. Reciprocal Rank Fusion
+    const merged = this.reciprocalRankFusion(vectorResults, ftsResults, k);
+
+    return merged.slice(0, limit);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private vectorSearch(embedding: Float32Array, limit: number, filters?: SearchFilters): RankedResult[] {
+    // sqlite-vec KNN query
+    // vec0 metadata filtering isn't fully flexible, so we fetch more and post-filter.
+    const rows = this.db.prepare(`
+      SELECT record_id, protocol_path, content_preview, category, collection, distance
+      FROM memory_embeddings
+      WHERE embedding MATCH ?
+        AND k = ?
+    `).all(embedding, limit * 2) as VecRow[];
+
+    let filtered = rows;
+    if (filters?.protocolPath) {
+      filtered = filtered.filter(r => r.protocol_path === filters.protocolPath);
+    }
+    if (filters?.category) {
+      filtered = filtered.filter(r => r.category === filters.category);
+    }
+    if (filters?.collection) {
+      filtered = filtered.filter(r => r.collection === filters.collection);
+    }
+
+    return filtered.slice(0, limit).map((r, i) => ({
+      recordId     : r.record_id,
+      protocolPath : r.protocol_path,
+      content      : r.content_preview,
+      category     : r.category ?? undefined,
+      collection   : r.collection ?? undefined,
+      rank         : i + 1,
+    }));
+  }
+
+  private ftsSearch(query: string, limit: number, filters?: SearchFilters): RankedResult[] {
+    // Escape FTS5 special characters and build query
+    const ftsQuery = query.replace(/['"]/g, '').trim();
+    if (!ftsQuery) { return []; }
+
+    // Build WHERE clause for filters
+    let filterClauses = '';
+    const params: (string | number)[] = [ftsQuery, limit];
+    if (filters?.protocolPath) {
+      filterClauses += ' AND protocol_path = ?';
+      params.push(filters.protocolPath);
+    }
+    if (filters?.category) {
+      filterClauses += ' AND category = ?';
+      params.push(filters.category);
+    }
+    if (filters?.collection) {
+      filterClauses += ' AND collection = ?';
+      params.push(filters.collection);
+    }
+
+    try {
+      const rows = this.db.prepare(`
+        SELECT record_id, protocol_path, content, category, collection, rank
+        FROM memory_fts
+        WHERE memory_fts MATCH ?${filterClauses}
+        ORDER BY rank
+        LIMIT ?
+      `).all(...params) as FtsRow[];
+
+      return rows.map((r, i) => ({
+        recordId     : r.record_id,
+        protocolPath : r.protocol_path,
+        content      : r.content,
+        category     : r.category ?? undefined,
+        collection   : r.collection ?? undefined,
+        rank         : i + 1,
+      }));
+    } catch {
+      // FTS5 can throw on malformed queries; return empty.
+      return [];
+    }
+  }
+
+  private reciprocalRankFusion(
+    vectorResults: RankedResult[],
+    ftsResults: RankedResult[],
+    k: number,
+  ): SearchResult[] {
+    const scores = new Map<string, { result: Omit<SearchResult, 'score'>; score: number }>();
+
+    for (const r of vectorResults) {
+      const existing = scores.get(r.recordId);
+      const rrfScore = 1 / (k + r.rank);
+      if (existing) {
+        existing.score += rrfScore;
+      } else {
+        scores.set(r.recordId, {
+          result: {
+            recordId     : r.recordId,
+            protocolPath : r.protocolPath,
+            content      : r.content,
+            category     : r.category,
+            collection   : r.collection,
+          },
+          score: rrfScore,
+        });
+      }
+    }
+
+    for (const r of ftsResults) {
+      const existing = scores.get(r.recordId);
+      const rrfScore = 1 / (k + r.rank);
+      if (existing) {
+        existing.score += rrfScore;
+      } else {
+        scores.set(r.recordId, {
+          result: {
+            recordId     : r.recordId,
+            protocolPath : r.protocolPath,
+            content      : r.content,
+            category     : r.category,
+            collection   : r.collection,
+          },
+          score: rrfScore,
+        });
+      }
+    }
+
+    return Array.from(scores.values())
+      .sort((a, b) => b.score - a.score)
+      .map(({ result, score }) => ({ ...result, score }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal row types
+// ---------------------------------------------------------------------------
+
+type VecRow = {
+  record_id: string;
+  protocol_path: string;
+  content_preview: string;
+  category: string | null;
+  collection: string | null;
+  distance: number;
+};
+
+type FtsRow = {
+  record_id: string;
+  protocol_path: string;
+  content: string;
+  category: string | null;
+  collection: string | null;
+  rank: number;
+};
+
+type RankedResult = {
+  recordId: string;
+  protocolPath: string;
+  content: string;
+  category?: string;
+  collection?: string;
+  rank: number;
+};

--- a/tests/sidecar/database.spec.ts
+++ b/tests/sidecar/database.spec.ts
@@ -1,0 +1,72 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+
+import { SidecarDatabase } from '../../src/sidecar/database.js';
+
+// ---------------------------------------------------------------------------
+// SidecarDatabase
+// ---------------------------------------------------------------------------
+
+describe('SidecarDatabase', () => {
+  let sidecar: SidecarDatabase | undefined;
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    sidecar?.close();
+    sidecar = undefined;
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('creates an in-memory database successfully', () => {
+    sidecar = new SidecarDatabase(':memory:');
+    expect(sidecar.db).toBeDefined();
+  });
+
+  it('creates all expected tables', () => {
+    sidecar = new SidecarDatabase(':memory:');
+
+    const tables = sidecar.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table', 'table') ORDER BY name`)
+      .all() as Array<{ name: string }>;
+
+    const tableNames = tables.map(t => t.name);
+
+    expect(tableNames).toContain('memory_embeddings');
+    expect(tableNames).toContain('memory_fts');
+    expect(tableNames).toContain('task_graph');
+    expect(tableNames).toContain('task_status');
+    expect(tableNames).toContain('sync_state');
+  });
+
+  it('is idempotent — can be constructed twice on the same database', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'memoryd-test-'));
+    const dbPath = join(tempDir, 'test.db');
+
+    const first = new SidecarDatabase(dbPath);
+    first.close();
+
+    // Second construction on the same file should not throw.
+    sidecar = new SidecarDatabase(dbPath);
+    expect(sidecar.db).toBeDefined();
+  });
+
+  it('close works without error', () => {
+    sidecar = new SidecarDatabase(':memory:');
+    expect(() => sidecar!.close()).not.toThrow();
+    sidecar = undefined; // Prevent double-close in afterEach
+  });
+
+  it('file-based database creates the file', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'memoryd-test-'));
+    const dbPath = join(tempDir, 'index.db');
+
+    expect(existsSync(dbPath)).toBe(false);
+    sidecar = new SidecarDatabase(dbPath);
+    expect(existsSync(dbPath)).toBe(true);
+  });
+});

--- a/tests/sidecar/search.spec.ts
+++ b/tests/sidecar/search.spec.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { NoopProvider } from '../../src/sidecar/embeddings.js';
+import { SearchIndex } from '../../src/sidecar/search.js';
+import { SidecarDatabase } from '../../src/sidecar/database.js';
+
+import type { IndexRecord } from '../../src/sidecar/search.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DIMS = 4;
+
+function makeRecord(overrides: Partial<IndexRecord> & { recordId: string; content: string }): IndexRecord {
+  return {
+    protocolPath: 'memory/v1/fact',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SearchIndex
+// ---------------------------------------------------------------------------
+
+describe('SearchIndex', () => {
+  let sidecar: SidecarDatabase;
+  let index: SearchIndex;
+
+  beforeEach(() => {
+    sidecar = new SidecarDatabase(':memory:', DIMS);
+    index = new SearchIndex(sidecar.db, new NoopProvider(DIMS));
+  });
+
+  afterEach(() => {
+    sidecar.close();
+  });
+
+  // -----------------------------------------------------------------------
+  // upsert
+  // -----------------------------------------------------------------------
+
+  it('upsert adds record to both vector and FTS indexes', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'TypeScript is great' }));
+
+    const vecRows = sidecar.db.prepare('SELECT record_id FROM memory_embeddings').all() as Array<{ record_id: string }>;
+    expect(vecRows).toHaveLength(1);
+    expect(vecRows[0].record_id).toBe('rec-1');
+
+    const ftsRows = sidecar.db.prepare('SELECT record_id FROM memory_fts').all() as Array<{ record_id: string }>;
+    expect(ftsRows).toHaveLength(1);
+    expect(ftsRows[0].record_id).toBe('rec-1');
+  });
+
+  it('upsert updates existing record (delete + re-insert)', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'old content' }));
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'new content' }));
+
+    const vecRows = sidecar.db.prepare('SELECT record_id FROM memory_embeddings').all();
+    expect(vecRows).toHaveLength(1);
+
+    const ftsRows = sidecar.db.prepare('SELECT content FROM memory_fts WHERE record_id = ?').all('rec-1') as Array<{ content: string }>;
+    expect(ftsRows).toHaveLength(1);
+    expect(ftsRows[0].content).toBe('new content');
+  });
+
+  // -----------------------------------------------------------------------
+  // remove
+  // -----------------------------------------------------------------------
+
+  it('remove deletes from both indexes', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'hello world' }));
+    index.remove('rec-1');
+
+    const vecRows = sidecar.db.prepare('SELECT record_id FROM memory_embeddings').all();
+    expect(vecRows).toHaveLength(0);
+
+    const ftsRows = sidecar.db.prepare('SELECT record_id FROM memory_fts').all();
+    expect(ftsRows).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // search — FTS is the real signal with NoopProvider
+  // -----------------------------------------------------------------------
+
+  it('search returns results from FTS', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'the quick brown fox' }));
+    await index.upsert(makeRecord({ recordId: 'rec-2', content: 'lazy dog sleeps' }));
+
+    const results = await index.search('fox');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some(r => r.recordId === 'rec-1')).toBe(true);
+  });
+
+  it('search filters by protocolPath', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'shared keyword', protocolPath: 'memory/v1/fact' }));
+    await index.upsert(makeRecord({ recordId: 'rec-2', content: 'shared keyword', protocolPath: 'task-graph/v1/task' }));
+
+    const results = await index.search('keyword', { filters: { protocolPath: 'task-graph/v1/task' } });
+    expect(results).toHaveLength(1);
+    expect(results[0].recordId).toBe('rec-2');
+  });
+
+  it('search filters by category', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'some data here', category: 'work' }));
+    await index.upsert(makeRecord({ recordId: 'rec-2', content: 'some data here', category: 'personal' }));
+
+    const results = await index.search('data', { filters: { category: 'personal' } });
+    expect(results).toHaveLength(1);
+    expect(results[0].recordId).toBe('rec-2');
+  });
+
+  it('search filters by collection', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'item alpha', collection: 'col-A' }));
+    await index.upsert(makeRecord({ recordId: 'rec-2', content: 'item alpha', collection: 'col-B' }));
+
+    const results = await index.search('alpha', { filters: { collection: 'col-A' } });
+    expect(results).toHaveLength(1);
+    expect(results[0].recordId).toBe('rec-1');
+  });
+
+  it('search respects limit', async () => {
+    for (let i = 0; i < 5; i++) {
+      await index.upsert(makeRecord({ recordId: `rec-${i}`, content: `common term number ${i}` }));
+    }
+
+    const results = await index.search('common', { limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  it('search returns empty for no matches', async () => {
+    // With NoopProvider, vector search returns all records (zero-dist).
+    // Use an empty database so neither FTS nor vector returns anything.
+    const results = await index.search('nonexistenttermxyz');
+    expect(results).toHaveLength(0);
+  });
+
+  it('search handles empty query gracefully', async () => {
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'hello world' }));
+
+    const results = await index.search('');
+    // Empty query should not crash; may return vector results (all zeros match)
+    // but FTS will return nothing for empty.
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // RRF score verification
+  // -----------------------------------------------------------------------
+
+  it('RRF merges results from both sources with correct scores', async () => {
+    // With NoopProvider, all embeddings are zero vectors. Vector search will
+    // return results in insertion order (all equidistant). FTS returns results
+    // ranked by BM25. A record appearing in both should have a higher RRF
+    // score than one appearing in only one source.
+    await index.upsert(makeRecord({ recordId: 'rec-1', content: 'unique apple fruit' }));
+    await index.upsert(makeRecord({ recordId: 'rec-2', content: 'unique banana fruit' }));
+
+    // Search for "apple" — rec-1 should appear in FTS, both in vector (zero-dist).
+    const results = await index.search('apple');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+
+    // The first result should be rec-1 (appears in both vector + FTS)
+    const rec1 = results.find(r => r.recordId === 'rec-1');
+    expect(rec1).toBeDefined();
+
+    // All scores should be positive
+    for (const r of results) {
+      expect(r.score).toBeGreaterThan(0);
+    }
+
+    // rec-1 should have higher score than rec-2 (if rec-2 is present) because
+    // rec-1 matches FTS while rec-2 does not.
+    const rec2 = results.find(r => r.recordId === 'rec-2');
+    if (rec1 && rec2) {
+      expect(rec1.score).toBeGreaterThan(rec2.score);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **`SidecarDatabase`** (`src/sidecar/database.ts`): SQLite lifecycle management class that loads the `sqlite-vec` extension, enables WAL mode, and creates all required tables — `memory_embeddings` (vec0 for vector KNN), `memory_fts` (FTS5 for full-text), `task_graph`, `task_status`, and `sync_state`. Idempotent via try/catch for vec0 and `IF NOT EXISTS` for other tables.
- **`SearchIndex`** (`src/sidecar/search.ts`): Hybrid search combining sqlite-vec KNN vector search with FTS5 BM25 full-text search, merged via Reciprocal Rank Fusion (RRF). Supports upsert, remove, and filtered search by protocolPath, category, and collection.
- **Tests**: Full test coverage for both classes in `tests/sidecar/database.spec.ts` (5 tests) and `tests/sidecar/search.spec.ts` (11 tests) including RRF score verification.
- **Exports**: Updated barrel exports in `src/sidecar/index.ts` and `src/index.ts`.

## Checks

- `bun run build` — zero TypeScript errors
- `bun run lint` — zero ESLint warnings/errors
- `bun test .spec.ts` — 125 tests pass (0 failures)

Closes #8