### PR TITLE
feat: add MCP server with stdio and HTTP transports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,6 @@ export { SidecarDatabase } from './sidecar/database.js';
 
 export { SearchIndex } from './sidecar/search.js';
 export type { IndexRecord, SearchFilters, SearchResult } from './sidecar/search.js';
+
+export { MemorydServer } from './mcp/server.js';
+export type { MemorydServerOptions } from './mcp/server.js';

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,1 +1,4 @@
 // memoryd MCP server — barrel export for @enbox/memoryd/mcp.
+
+export { MemorydServer } from './server.js';
+export type { MemorydServerOptions } from './server.js';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,110 @@
+// memoryd MCP server — wraps @modelcontextprotocol/sdk with Bun HTTP transport.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+
+export type MemorydServerOptions = {
+  port?: number;
+  version?: string;
+};
+
+/**
+ * MCP server for memoryd.
+ *
+ * Wraps {@link McpServer} and exposes two transport modes:
+ *
+ * - **stdio** — for CLI / pipe integration (most MCP clients use this).
+ * - **HTTP**  — daemon mode via `Bun.serve()` using the Web-Standard
+ *   Streamable HTTP transport from the MCP SDK.
+ */
+export class MemorydServer {
+  readonly mcp: McpServer;
+
+  private httpServer: ReturnType<typeof Bun.serve> | undefined;
+  private transport: WebStandardStreamableHTTPServerTransport | undefined;
+
+  private readonly port: number;
+  private readonly version: string;
+
+  constructor(opts?: MemorydServerOptions) {
+    this.port = opts?.port ?? 3200;
+    this.version = opts?.version ?? '0.0.1';
+
+    this.mcp = new McpServer(
+      { name: 'memoryd', version: this.version },
+      {
+        capabilities: {
+          tools     : {},
+          resources : { subscribe: true },
+          prompts   : {},
+          logging   : {},
+        },
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stdio transport (CLI / pipe mode)
+  // ---------------------------------------------------------------------------
+
+  async startStdio(): Promise<void> {
+    const { StdioServerTransport } = await import(
+      '@modelcontextprotocol/sdk/server/stdio.js'
+    );
+    const transport = new StdioServerTransport();
+    await this.mcp.connect(transport);
+  }
+
+  // ---------------------------------------------------------------------------
+  // HTTP transport (daemon mode)
+  // ---------------------------------------------------------------------------
+
+  async startHttp(): Promise<{ port: number }> {
+    const { WebStandardStreamableHTTPServerTransport } = await import(
+      '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+    );
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: (): string => crypto.randomUUID(),
+    });
+
+    this.transport = transport;
+    await this.mcp.connect(transport);
+
+    const version = this.version;
+
+    this.httpServer = Bun.serve({
+      port: this.port,
+      async fetch(req: Request): Promise<Response> {
+        const url = new URL(req.url);
+
+        if (url.pathname === '/health') {
+          return Response.json({
+            status  : 'ok',
+            name    : 'memoryd',
+            version : version,
+          });
+        }
+
+        if (url.pathname === '/mcp') {
+          return transport.handleRequest(req);
+        }
+
+        return new Response('Not Found', { status: 404 });
+      },
+    });
+
+    return { port: this.httpServer.port ?? this.port };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shutdown
+  // ---------------------------------------------------------------------------
+
+  async stop(): Promise<void> {
+    this.httpServer?.stop();
+    await this.mcp.close();
+    this.httpServer = undefined;
+    this.transport = undefined;
+  }
+}

--- a/tests/mcp/server.spec.ts
+++ b/tests/mcp/server.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { MemorydServer } from '../../src/mcp/server.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let server: MemorydServer | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await server.stop();
+    server = undefined;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+describe('MemorydServer — constructor', () => {
+  it('creates a server with default options', () => {
+    server = new MemorydServer();
+    expect(server).toBeInstanceOf(MemorydServer);
+    expect(server.mcp).toBeDefined();
+  });
+
+  it('accepts custom port and version', () => {
+    server = new MemorydServer({ port: 4567, version: '1.2.3' });
+    expect(server).toBeInstanceOf(MemorydServer);
+    expect(server.mcp).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP transport
+// ---------------------------------------------------------------------------
+
+describe('MemorydServer — startHttp', () => {
+  it('starts an HTTP server and returns the actual port', async () => {
+    server = new MemorydServer({ port: 0 });
+    const result = await server.startHttp();
+    expect(result.port).toBeGreaterThan(0);
+  });
+
+  it('health endpoint returns 200 with status ok', async () => {
+    server = new MemorydServer({ port: 0 });
+    const { port } = await server.startHttp();
+
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { status: string; name: string; version: string };
+    expect(body.status).toBe('ok');
+    expect(body.name).toBe('memoryd');
+    expect(body.version).toBe('0.0.1');
+  });
+
+  it('health endpoint reflects custom version', async () => {
+    server = new MemorydServer({ port: 0, version: '2.0.0' });
+    const { port } = await server.startHttp();
+
+    const res = await fetch(`http://localhost:${port}/health`);
+    const body = await res.json() as { version: string };
+    expect(body.version).toBe('2.0.0');
+  });
+
+  it('unknown routes return 404', async () => {
+    server = new MemorydServer({ port: 0 });
+    const { port } = await server.startHttp();
+
+    const res = await fetch(`http://localhost:${port}/does-not-exist`);
+    expect(res.status).toBe(404);
+
+    const text = await res.text();
+    expect(text).toBe('Not Found');
+  });
+
+  it('/mcp endpoint exists and handles POST (MCP protocol)', async () => {
+    server = new MemorydServer({ port: 0 });
+    const { port } = await server.startHttp();
+
+    // Send an initialize JSON-RPC request to the MCP endpoint.
+    // The MCP Streamable HTTP transport requires Accept headers.
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method  : 'POST',
+      headers : {
+        'Content-Type' : 'application/json',
+        'Accept'       : 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc : '2.0',
+        id      : 1,
+        method  : 'initialize',
+        params  : {
+          protocolVersion : '2025-03-26',
+          capabilities    : {},
+          clientInfo      : { name: 'test-client', version: '0.1.0' },
+        },
+      }),
+    });
+
+    // The transport should respond (200 for SSE stream, 202 for accepted)
+    expect([200, 202]).toContain(res.status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+describe('MemorydServer — capabilities', () => {
+  it('McpServer instance exposes the low-level Server', () => {
+    server = new MemorydServer();
+    // The McpServer has a `server` property (low-level Server)
+    expect(server.mcp.server).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+describe('MemorydServer — stop', () => {
+  it('stop is safe to call multiple times', async () => {
+    server = new MemorydServer({ port: 0 });
+    await server.startHttp();
+
+    await server.stop();
+    await server.stop(); // should not throw
+    server = undefined; // prevent afterEach from stopping again
+  });
+
+  it('stop shuts down the HTTP server', async () => {
+    server = new MemorydServer({ port: 0 });
+    const { port } = await server.startHttp();
+
+    // Verify server is running
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+
+    await server.stop();
+    server = undefined;
+
+    // After stop, the server should no longer respond
+    try {
+      await fetch(`http://localhost:${port}/health`);
+      // If the fetch succeeds, the server is still running — fail the test
+      expect(true).toBe(false);
+    } catch {
+      // Expected: connection refused or similar error
+      expect(true).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `MemorydServer` class wrapping `@modelcontextprotocol/sdk` `McpServer` with two transport modes: **stdio** (CLI/pipe) and **HTTP** (daemon via `Bun.serve()` with Streamable HTTP transport).
- Exposes `/health` endpoint (JSON status) and `/mcp` endpoint (MCP protocol).
- Declares capabilities for tools, resources (with subscribe), prompts, and logging — ready for tools/resources to be registered in subsequent PRs.
- Barrel exports from `src/mcp/index.ts` and `src/index.ts`.
- 10 integration tests covering constructor, HTTP transport, health endpoint, MCP protocol endpoint, capabilities, and shutdown.

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 119 tests pass (10 new)
- `bun run lint` — zero warnings

Closes #10