### PR TITLE
feat: add MCP memory tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,5 @@ export type { IndexRecord, SearchFilters, SearchResult } from './sidecar/search.
 
 export { MemorydServer } from './mcp/server.js';
 export type { MemorydServerOptions } from './mcp/server.js';
+
+export { registerMemoryTools } from './mcp/tools/memory-tools.js';

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,3 +2,5 @@
 
 export { MemorydServer } from './server.js';
 export type { MemorydServerOptions } from './server.js';
+
+export { registerMemoryTools } from './tools/memory-tools.js';

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,0 +1,1 @@
+export { registerMemoryTools } from './memory-tools.js';

--- a/src/mcp/tools/memory-tools.ts
+++ b/src/mcp/tools/memory-tools.ts
@@ -1,0 +1,217 @@
+// memoryd MCP tools — memory_add_fact, memory_add_preference, memory_search,
+// memory_supersede, memory_compact.
+
+import type { MemorydServer } from '../server.js';
+import type { MemoryStore } from '../../core/memory-store.js';
+import type { SearchIndex } from '../../sidecar/search.js';
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Loose audit-typed interface — avoids importing protocol internals.
+// ---------------------------------------------------------------------------
+
+type AuditTyped = {
+  records: {
+    create: (type: string, opts: {
+      data : Record<string, unknown>;
+      tags : Record<string, string>;
+    }) => Promise<unknown>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ToolContent = {
+  content : { type: 'text'; text: string }[];
+  isError? : boolean;
+};
+
+function jsonResult(data: unknown): ToolContent {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult(err: unknown): ToolContent {
+  const message = err instanceof Error ? err.message : String(err);
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}
+
+async function writeAudit(
+  auditTyped: AuditTyped | undefined,
+  action: string,
+  description: string,
+  targetRecordId: string,
+): Promise<void> {
+  if (!auditTyped) { return; }
+  await auditTyped.records.create('actionLog', {
+    data : { description },
+    tags : {
+      agentDid       : 'self',
+      action,
+      targetProtocol : 'memory/v1',
+      targetRecordId,
+      status         : 'success',
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// registerMemoryTools
+// ---------------------------------------------------------------------------
+
+export function registerMemoryTools(
+  server: MemorydServer,
+  memoryStore: MemoryStore,
+  searchIndex?: SearchIndex,
+  auditTyped?: AuditTyped,
+): void {
+  // -----------------------------------------------------------------------
+  // memory_add_fact
+  // -----------------------------------------------------------------------
+
+  server.mcp.registerTool('memory_add_fact', {
+    description : 'Add a new fact to the user\'s memory store.',
+    inputSchema : {
+      content    : z.string().describe('The fact content to store.'),
+      category   : z.string().describe('Category for the fact (e.g. personal, work, health).'),
+      source     : z.string().default('agent').describe('Source of the fact (e.g. user, agent).'),
+      confidence : z.number().min(0).max(1).optional().describe('Confidence score between 0 and 1.'),
+      collection : z.string().optional().describe('Optional collection to group the fact into.'),
+    },
+  }, async (args) => {
+    try {
+      const result = await memoryStore.addFact(args.content, args.category, args.source, {
+        confidence : args.confidence,
+        collection : args.collection,
+      });
+      await writeAudit(auditTyped, 'memory_add_fact', `Added fact: ${args.content.substring(0, 50)}`, result.id);
+      return jsonResult(result);
+    } catch (err) {
+      return errorResult(err);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // memory_add_preference
+  // -----------------------------------------------------------------------
+
+  server.mcp.registerTool('memory_add_preference', {
+    description : 'Add a new preference to the user\'s memory store.',
+    inputSchema : {
+      content    : z.string().describe('The preference content to store.'),
+      domain     : z.string().describe('Domain for the preference (e.g. ui, accessibility, communication).'),
+      collection : z.string().optional().describe('Optional collection to group the preference into.'),
+    },
+  }, async (args) => {
+    try {
+      const result = await memoryStore.addPreference(args.content, args.domain, {
+        collection: args.collection,
+      });
+      await writeAudit(auditTyped, 'memory_add_preference', `Added preference: ${args.content.substring(0, 50)}`, result.id);
+      return jsonResult(result);
+    } catch (err) {
+      return errorResult(err);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // memory_search
+  // -----------------------------------------------------------------------
+
+  server.mcp.registerTool('memory_search', {
+    description : 'Search the user\'s memory store for facts and preferences.',
+    inputSchema : {
+      query      : z.string().optional().describe('Free-text search query. Uses hybrid vector+FTS if search index is available.'),
+      category   : z.string().optional().describe('Filter by fact category.'),
+      domain     : z.string().optional().describe('Filter by preference domain.'),
+      collection : z.string().optional().describe('Filter by collection.'),
+      limit      : z.number().int().min(1).max(100).default(10).describe('Maximum number of results to return.'),
+    },
+  }, async (args) => {
+    try {
+      // If a search index is available and a query is provided, use hybrid search.
+      if (searchIndex && args.query) {
+        const filters: Record<string, string> = {};
+        if (args.category) { filters.category = args.category; }
+        if (args.collection) { filters.collection = args.collection; }
+
+        const results = await searchIndex.search(args.query, {
+          limit   : args.limit,
+          filters : Object.keys(filters).length > 0 ? filters : undefined,
+        });
+
+        await writeAudit(
+          auditTyped, 'memory_search',
+          `Searched: ${args.query.substring(0, 50)}`,
+          `query:${args.query.substring(0, 30)}`,
+        );
+        return jsonResult(results);
+      }
+
+      // Fallback: list facts from the memory store with tag filters.
+      const filters: Record<string, string> = {};
+      if (args.category) { filters.category = args.category; }
+      if (args.collection) { filters.collection = args.collection; }
+
+      const listResult = await memoryStore.listFacts(
+        Object.keys(filters).length > 0 ? filters : undefined,
+        { limit: args.limit },
+      );
+
+      await writeAudit(
+        auditTyped, 'memory_search',
+        `Listed facts${args.category ? ` in category ${args.category}` : ''}`,
+        'list',
+      );
+      return jsonResult(listResult.records);
+    } catch (err) {
+      return errorResult(err);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // memory_supersede
+  // -----------------------------------------------------------------------
+
+  server.mcp.registerTool('memory_supersede', {
+    description : 'Replace an existing fact with updated content, marking the old fact as superseded.',
+    inputSchema : {
+      oldFactId  : z.string().describe('The record ID of the fact to supersede.'),
+      newContent : z.string().describe('The updated fact content.'),
+      reason     : z.string().optional().describe('Reason for superseding the old fact.'),
+    },
+  }, async (args) => {
+    try {
+      const result = await memoryStore.supersedeFact(args.oldFactId, args.newContent, {
+        reason: args.reason,
+      });
+      await writeAudit(
+        auditTyped, 'memory_supersede',
+        `Superseded fact ${args.oldFactId.substring(0, 20)}: ${args.newContent.substring(0, 30)}`,
+        result.id,
+      );
+      return jsonResult(result);
+    } catch (err) {
+      return errorResult(err);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // memory_compact
+  // -----------------------------------------------------------------------
+
+  server.mcp.registerTool('memory_compact', {
+    description : 'Compact the memory store by merging or pruning old entries. (Not yet implemented — see Issue #15.)',
+    inputSchema : {
+      olderThan  : z.string().optional().describe('ISO 8601 date — compact records older than this date.'),
+      collection : z.string().optional().describe('Limit compaction to a specific collection.'),
+    },
+  }, async (_args) => {
+    return jsonResult({
+      status  : 'not_implemented',
+      message : 'Memory compaction is not yet implemented. See Issue #15.',
+    });
+  });
+}

--- a/tests/mcp/tools/memory-tools.spec.ts
+++ b/tests/mcp/tools/memory-tools.spec.ts
@@ -1,0 +1,233 @@
+import { rmSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { MemorydServer } from '../../../src/mcp/server.js';
+import { MemoryProtocol } from '../../../src/protocols/memory.js';
+import { MemoryStore } from '../../../src/core/memory-store.js';
+import { registerMemoryTools } from '../../../src/mcp/tools/memory-tools.js';
+
+const DATA_PATH = '__TESTDATA__/memory-tools';
+
+describe('memory tools (MCP)', () => {
+  let server: MemorydServer;
+  let store: MemoryStore;
+  let client: Client;
+  let port: number;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+
+    // ----- DWN agent + identity -----
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test' });
+    await agent.start({ password: 'test' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Test' },
+        didOptions : {
+          verificationMethods: [
+            {
+              algorithm : 'Ed25519',
+              id        : 'sig',
+              purposes  : ['assertionMethod', 'authentication'],
+            },
+            {
+              algorithm : 'X25519',
+              id        : 'enc',
+              purposes  : ['keyAgreement'],
+            },
+          ],
+        },
+      });
+    }
+
+    const { web5 } = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    // Configure protocol
+    const typed = web5.using(MemoryProtocol);
+    await typed.configure({ encryption: true });
+
+    store = new MemoryStore(web5);
+
+    // ----- MCP server -----
+    server = new MemorydServer({ port: 0 });
+    registerMemoryTools(server, store);
+    const result = await server.startHttp();
+    port = result.port;
+
+    // ----- MCP client -----
+    client = new Client({ name: 'test-client', version: '0.1.0' });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/mcp`),
+    );
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client?.close();
+    await server?.stop();
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool listing
+  // -------------------------------------------------------------------------
+
+  it('lists all 5 memory tools', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map(t => t.name);
+    expect(names).toContain('memory_add_fact');
+    expect(names).toContain('memory_add_preference');
+    expect(names).toContain('memory_search');
+    expect(names).toContain('memory_supersede');
+    expect(names).toContain('memory_compact');
+  });
+
+  // -------------------------------------------------------------------------
+  // memory_add_fact
+  // -------------------------------------------------------------------------
+
+  it('memory_add_fact creates a fact and returns result with id', async () => {
+    const result = await client.callTool({
+      name      : 'memory_add_fact',
+      arguments : {
+        content  : 'User prefers TypeScript',
+        category : 'technical',
+        source   : 'user',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse((result.content as { type: string; text: string }[])[0].text);
+    expect(parsed.id).toBeDefined();
+    expect(typeof parsed.id).toBe('string');
+    expect(parsed.status.code).toBe(202);
+  });
+
+  // -------------------------------------------------------------------------
+  // memory_add_preference
+  // -------------------------------------------------------------------------
+
+  it('memory_add_preference creates a preference', async () => {
+    const result = await client.callTool({
+      name      : 'memory_add_preference',
+      arguments : {
+        content : 'Dark mode preferred',
+        domain  : 'ui',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse((result.content as { type: string; text: string }[])[0].text);
+    expect(parsed.id).toBeDefined();
+    expect(parsed.status.code).toBe(202);
+  });
+
+  // -------------------------------------------------------------------------
+  // memory_search — fallback to listFacts
+  // -------------------------------------------------------------------------
+
+  it('memory_search without search index falls back to listing facts', async () => {
+    // Add a fact first so there's something to find
+    await client.callTool({
+      name      : 'memory_add_fact',
+      arguments : {
+        content  : 'Searchable fact about cats',
+        category : 'animals',
+        source   : 'user',
+      },
+    });
+
+    const result = await client.callTool({
+      name      : 'memory_search',
+      arguments : { category: 'animals' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse((result.content as { type: string; text: string }[])[0].text);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed[0].data.content).toContain('cats');
+  });
+
+  // -------------------------------------------------------------------------
+  // memory_supersede
+  // -------------------------------------------------------------------------
+
+  it('memory_supersede replaces a fact', async () => {
+    // Create initial fact
+    const addResult = await client.callTool({
+      name      : 'memory_add_fact',
+      arguments : {
+        content  : 'Old fact to supersede',
+        category : 'test-supersede',
+        source   : 'user',
+      },
+    });
+    const addParsed = JSON.parse((addResult.content as { type: string; text: string }[])[0].text);
+    const oldId = addParsed.id;
+
+    // Supersede it
+    const supersedeResult = await client.callTool({
+      name      : 'memory_supersede',
+      arguments : {
+        oldFactId  : oldId,
+        newContent : 'New superseding fact',
+        reason     : 'Updated information',
+      },
+    });
+
+    expect(supersedeResult.isError).toBeFalsy();
+    const parsed = JSON.parse((supersedeResult.content as { type: string; text: string }[])[0].text);
+    expect(parsed.id).toBeDefined();
+    expect(parsed.id).not.toBe(oldId);
+    expect(parsed.status.code).toBe(202);
+  });
+
+  // -------------------------------------------------------------------------
+  // memory_compact — stub
+  // -------------------------------------------------------------------------
+
+  it('memory_compact returns not-yet-implemented message', async () => {
+    const result = await client.callTool({
+      name      : 'memory_compact',
+      arguments : {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse((result.content as { type: string; text: string }[])[0].text);
+    expect(parsed.status).toBe('not_implemented');
+    expect(parsed.message).toContain('not yet implemented');
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  it('returns error for invalid supersede with non-existent record', async () => {
+    const result = await client.callTool({
+      name      : 'memory_supersede',
+      arguments : {
+        oldFactId  : 'non-existent-record-id',
+        newContent : 'Should fail',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Registers 5 MCP tools for personal memory operations via `registerMemoryTools()`:
  - **`memory_add_fact`** — store a durable fact with category, confidence, collection
  - **`memory_add_preference`** — store a user preference with domain
  - **`memory_search`** — hybrid search (vector+FTS via sidecar) with fallback to DWN tag queries
  - **`memory_supersede`** — replace a fact while preserving supersession history chain
  - **`memory_compact`** — stub for future compaction (Issue #15)
- Each tool uses Zod v4 schemas for input validation, returns structured JSON, writes audit log records when configured, and handles errors gracefully
- 7 integration tests using MCP Client SDK over HTTP transport
- Barrel exports from `src/mcp/index.ts` and `src/index.ts`

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 142 tests pass (7 new)
- `bun run lint` — zero warnings

Closes #11