### PR TITLE
feat: add MCP task tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,4 @@ export { MemorydServer } from './mcp/server.js';
 export type { MemorydServerOptions } from './mcp/server.js';
 
 export { registerMemoryTools } from './mcp/tools/memory-tools.js';
+export { registerTaskTools } from './mcp/tools/task-tools.js';

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,3 +4,4 @@ export { MemorydServer } from './server.js';
 export type { MemorydServerOptions } from './server.js';
 
 export { registerMemoryTools } from './tools/memory-tools.js';
+export { registerTaskTools } from './tools/task-tools.js';

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,1 +1,2 @@
 export { registerMemoryTools } from './memory-tools.js';
+export { registerTaskTools } from './task-tools.js';

--- a/src/mcp/tools/task-tools.ts
+++ b/src/mcp/tools/task-tools.ts
@@ -1,0 +1,380 @@
+// MCP task tools — registers task-graph tools on the MCP server.
+
+import { z } from 'zod';
+
+import type { GraphEngine } from '../../core/graph.js';
+import type { MemorydServer } from '../../mcp/server.js';
+import type { TaskStore } from '../../core/task-store.js';
+
+// ---------------------------------------------------------------------------
+// Audit helper type
+// ---------------------------------------------------------------------------
+
+type AuditTyped = {
+  records: {
+    create: (
+      type: 'actionLog',
+      opts: {
+        data: { description: string };
+        tags: {
+          agentDid: string;
+          action: string;
+          targetProtocol: string;
+          targetRecordId: string;
+          status: string;
+        };
+      },
+    ) => Promise<unknown>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+type ToolResponse = {
+  content: { type: 'text'; text: string }[];
+  isError?: true;
+};
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+function jsonContent(data: unknown): ToolResponse {
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function errorContent(message: string): ToolResponse {
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}
+
+// ---------------------------------------------------------------------------
+// Audit helper
+// ---------------------------------------------------------------------------
+
+async function writeAudit(
+  auditTyped: AuditTyped | undefined,
+  action: string,
+  description: string,
+  targetRecordId: string,
+): Promise<void> {
+  if (!auditTyped) {
+    return;
+  }
+
+  await auditTyped.records.create('actionLog', {
+    data : { description },
+    tags : {
+      agentDid       : 'self',
+      action,
+      targetProtocol : 'task-graph/v1',
+      targetRecordId,
+      status         : 'success',
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Register task tools
+// ---------------------------------------------------------------------------
+
+export function registerTaskTools(
+  server: MemorydServer,
+  taskStore: TaskStore,
+  graphEngine: GraphEngine,
+  auditTyped?: AuditTyped,
+): void {
+  // -------------------------------------------------------------------------
+  // task_create
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_create',
+    {
+      description : 'Create a new task or subtask in the task graph.',
+      inputSchema : {
+        title        : z.string().describe('Title of the task'),
+        description  : z.string().optional().describe('Description of the task'),
+        priority     : z.enum(['p0', 'p1', 'p2', 'p3']).describe('Priority level'),
+        type         : z.string().optional().describe('Task type (e.g. feature, bug)'),
+        parentTaskId : z.string().optional().describe('Parent task ID for creating a subtask'),
+        collection   : z.string().optional().describe('Collection to group the task'),
+      },
+    },
+    async ({ title, description, priority, type, parentTaskId, collection }): Promise<ToolResponse> => {
+      try {
+        if (parentTaskId) {
+          const parent = await taskStore.getTask(parentTaskId);
+          const result = await taskStore.createSubtask(parent.contextId!, title, priority, {
+            description,
+            type,
+            collection,
+          });
+
+          await writeAudit(
+            auditTyped,
+            'task_create',
+            `Created subtask: ${title.substring(0, 50)}`,
+            result.id,
+          );
+
+          return jsonContent(result);
+        }
+
+        const result = await taskStore.createTask(title, priority, {
+          description,
+          type,
+          collection,
+        });
+
+        await writeAudit(
+          auditTyped,
+          'task_create',
+          `Created task: ${title.substring(0, 50)}`,
+          result.id,
+        );
+
+        return jsonContent(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_update
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_update',
+    {
+      description : 'Update an existing task (status, priority, assignee) or claim it.',
+      inputSchema : {
+        taskId   : z.string().describe('ID of the task to update'),
+        status   : z.string().optional().describe('New status'),
+        priority : z.string().optional().describe('New priority'),
+        assignee : z.string().optional().describe('Assignee DID or name'),
+        claim    : z.boolean().optional().describe('If true, atomically claim the task'),
+      },
+    },
+    async ({ taskId, status, priority, assignee, claim }): Promise<ToolResponse> => {
+      try {
+        if (claim) {
+          const result = await taskStore.claimTask(taskId, assignee ?? 'agent');
+
+          await writeAudit(
+            auditTyped,
+            'task_update',
+            `Claimed task: ${taskId.substring(0, 50)}`,
+            taskId,
+          );
+
+          return jsonContent(result);
+        }
+
+        const updates: Record<string, string> = {};
+        if (status !== undefined) { updates.status = status; }
+        if (priority !== undefined) { updates.priority = priority; }
+        if (assignee !== undefined) { updates.assignee = assignee; }
+
+        const result = await taskStore.updateTask(taskId, updates);
+
+        await writeAudit(
+          auditTyped,
+          'task_update',
+          `Updated task: ${taskId.substring(0, 50)}`,
+          taskId,
+        );
+
+        return jsonContent(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_add_dependency
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_add_dependency',
+    {
+      description : 'Add a dependency between tasks (with cycle detection).',
+      inputSchema : {
+        taskId    : z.string().describe('ID of the task that will be blocked'),
+        dependsOn : z.string().describe('ID of the blocking task'),
+        type      : z.string().default('blocks').describe('Dependency type'),
+      },
+    },
+    async ({ taskId, dependsOn, type }): Promise<ToolResponse> => {
+      try {
+        const cycle = await graphEngine.detectCycle(taskId, dependsOn);
+        if (cycle) {
+          return errorContent(`Cycle detected: ${cycle.join(' → ')}`);
+        }
+
+        const task = await taskStore.getTask(taskId);
+        await taskStore.addDependency(task.contextId!, dependsOn, type);
+
+        await writeAudit(
+          auditTyped,
+          'task_add_dependency',
+          `Added dependency: ${taskId.substring(0, 20)} depends on ${dependsOn.substring(0, 20)}`,
+          taskId,
+        );
+
+        return jsonContent({ success: true, taskId, dependsOn, type });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_ready
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_ready',
+    {
+      description : 'List tasks that are ready to work on (all blockers resolved).',
+      inputSchema : {
+        collection : z.string().optional().describe('Filter by collection'),
+        priority   : z.string().optional().describe('Filter by priority'),
+      },
+    },
+    async ({ collection, priority }): Promise<ToolResponse> => {
+      try {
+        const ready = await graphEngine.getReadyTasks({ collection, priority });
+
+        await writeAudit(
+          auditTyped,
+          'task_ready',
+          `Listed ${ready.length} ready tasks`,
+          'query',
+        );
+
+        return jsonContent(ready);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_show
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_show',
+    {
+      description : 'Show full details of a task including subtasks, dependencies, notes.',
+      inputSchema : {
+        taskId: z.string().describe('ID of the task to show'),
+      },
+    },
+    async ({ taskId }): Promise<ToolResponse> => {
+      try {
+        const detail = await taskStore.getTask(taskId);
+
+        await writeAudit(
+          auditTyped,
+          'task_show',
+          `Showed task: ${taskId.substring(0, 50)}`,
+          taskId,
+        );
+
+        return jsonContent(detail);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_list
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_list',
+    {
+      description : 'List tasks with optional filters.',
+      inputSchema : {
+        status     : z.string().optional().describe('Filter by status'),
+        priority   : z.string().optional().describe('Filter by priority'),
+        assignee   : z.string().optional().describe('Filter by assignee'),
+        type       : z.string().optional().describe('Filter by task type'),
+        collection : z.string().optional().describe('Filter by collection'),
+        limit      : z.number().optional().describe('Maximum number of tasks to return'),
+      },
+    },
+    async ({ status, priority, assignee, type, collection, limit }): Promise<ToolResponse> => {
+      try {
+        const filters: Record<string, string> = {};
+        if (status !== undefined) { filters.status = status; }
+        if (priority !== undefined) { filters.priority = priority; }
+        if (assignee !== undefined) { filters.assignee = assignee; }
+        if (type !== undefined) { filters.type = type; }
+        if (collection !== undefined) { filters.collection = collection; }
+
+        const hasFilters = Object.keys(filters).length > 0;
+        const result = await taskStore.listTasks(
+          hasFilters ? filters : undefined,
+          limit !== undefined ? { limit } : undefined,
+        );
+
+        await writeAudit(
+          auditTyped,
+          'task_list',
+          `Listed ${result.records.length} tasks`,
+          'query',
+        );
+
+        return jsonContent(result);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // task_add_note
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerTool(
+    'task_add_note',
+    {
+      description : 'Add a note to a task.',
+      inputSchema : {
+        taskId  : z.string().describe('ID of the task to annotate'),
+        content : z.string().describe('Note content'),
+      },
+    },
+    async ({ taskId, content }): Promise<ToolResponse> => {
+      try {
+        const task = await taskStore.getTask(taskId);
+        await taskStore.addNote(task.contextId!, content);
+
+        await writeAudit(
+          auditTyped,
+          'task_add_note',
+          `Added note to task: ${taskId.substring(0, 50)}`,
+          taskId,
+        );
+
+        return jsonContent({ success: true, taskId });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorContent(message);
+      }
+    },
+  );
+}

--- a/tests/mcp/tools/task-tools.spec.ts
+++ b/tests/mcp/tools/task-tools.spec.ts
@@ -1,0 +1,406 @@
+import { rmSync } from 'node:fs';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { GraphEngine } from '../../../src/core/graph.js';
+import { MemorydServer } from '../../../src/mcp/server.js';
+import { registerTaskTools } from '../../../src/mcp/tools/task-tools.js';
+import { TaskStore } from '../../../src/core/task-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/task-tools';
+
+type ToolResult = {
+  content: { type: string; text: string }[];
+  isError?: boolean;
+};
+
+function parseResult(result: ToolResult): unknown {
+  const text = result.content[0]?.text;
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let server: MemorydServer;
+let client: Client;
+let taskStore: TaskStore;
+let port: number;
+
+beforeAll(async () => {
+  rmSync(DATA_PATH, { recursive: true, force: true });
+
+  const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+  await agent.initialize({ password: 'test' });
+  await agent.start({ password: 'test' });
+
+  const identities = await agent.identity.list();
+  let identity = identities[0];
+  if (!identity) {
+    identity = await agent.identity.create({
+      didMethod  : 'dht',
+      metadata   : { name: 'Test' },
+      didOptions : {
+        verificationMethods: [
+          { algorithm: 'Ed25519', purposes: ['authentication', 'assertionMethod'] },
+          { algorithm: 'X25519', purposes: ['keyAgreement'] },
+        ],
+      },
+    });
+  }
+
+  const result = await Web5.connect({
+    agent,
+    connectedDid : identity.did.uri,
+    sync         : 'off',
+  });
+
+  taskStore = new TaskStore(result.web5);
+  const graphEngine = new GraphEngine(taskStore);
+
+  server = new MemorydServer({ port: 0 });
+  registerTaskTools(server, taskStore, graphEngine);
+  const httpResult = await server.startHttp();
+  port = httpResult.port;
+
+  client = new Client({ name: 'test', version: '0.1.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/mcp`),
+  );
+  await client.connect(transport);
+}, 30_000);
+
+afterAll(async () => {
+  await client.close();
+  await server.stop();
+  rmSync(DATA_PATH, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('task tools — registration', () => {
+  it('listTools shows all 7 task tools registered', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+
+    expect(names).toContain('task_create');
+    expect(names).toContain('task_update');
+    expect(names).toContain('task_add_dependency');
+    expect(names).toContain('task_ready');
+    expect(names).toContain('task_show');
+    expect(names).toContain('task_list');
+    expect(names).toContain('task_add_note');
+    expect(names.filter((n) => n.startsWith('task_')).length).toBe(7);
+  }, 30_000);
+});
+
+describe('task tools — task_create', () => {
+  it('creates a task', async () => {
+    const result = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Test task', priority: 'p1' },
+    }) as ToolResult;
+
+    expect(result.isError).toBeUndefined();
+    const parsed = parseResult(result) as { id: string; contextId: string; status: { code: number } };
+    expect(parsed.id).toBeDefined();
+    expect(typeof parsed.id).toBe('string');
+    expect(parsed.contextId).toBeDefined();
+    expect(parsed.status.code).toBe(202);
+  }, 30_000);
+
+  it('creates a subtask with parentTaskId', async () => {
+    // Create parent first
+    const parentResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Parent task', priority: 'p1' },
+    }) as ToolResult;
+    const parent = parseResult(parentResult) as { id: string };
+
+    // Create subtask
+    const subResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Subtask', priority: 'p2', parentTaskId: parent.id },
+    }) as ToolResult;
+
+    expect(subResult.isError).toBeUndefined();
+    const parsed = parseResult(subResult) as { id: string; contextId: string; status: { code: number } };
+    expect(parsed.id).toBeDefined();
+    expect(parsed.status.code).toBe(202);
+
+    // Verify parent shows subtask
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: parent.id },
+    }) as ToolResult;
+    const detail = parseResult(showResult) as { subtasks: { data: { title: string } }[] };
+    expect(detail.subtasks.length).toBe(1);
+    expect(detail.subtasks[0].data.title).toBe('Subtask');
+  }, 30_000);
+});
+
+describe('task tools — task_update', () => {
+  it('changes status', async () => {
+    const createResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Update me', priority: 'p2' },
+    }) as ToolResult;
+    const created = parseResult(createResult) as { id: string };
+
+    const updateResult = await client.callTool({
+      name      : 'task_update',
+      arguments : { taskId: created.id, status: 'in_progress' },
+    }) as ToolResult;
+
+    expect(updateResult.isError).toBeUndefined();
+
+    // Verify status changed
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: created.id },
+    }) as ToolResult;
+    const detail = parseResult(showResult) as { tags: { status: string } };
+    expect(detail.tags.status).toBe('in_progress');
+  }, 30_000);
+
+  it('with claim=true does atomic claim', async () => {
+    const createResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Claim me', priority: 'p1' },
+    }) as ToolResult;
+    const created = parseResult(createResult) as { id: string };
+
+    const claimResult = await client.callTool({
+      name      : 'task_update',
+      arguments : { taskId: created.id, claim: true, assignee: 'did:example:alice' },
+    }) as ToolResult;
+
+    expect(claimResult.isError).toBeUndefined();
+
+    // Verify claim
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: created.id },
+    }) as ToolResult;
+    const detail = parseResult(showResult) as { tags: { status: string; assignee: string } };
+    expect(detail.tags.status).toBe('in_progress');
+    expect(detail.tags.assignee).toBe('did:example:alice');
+  }, 30_000);
+});
+
+describe('task tools — task_add_dependency', () => {
+  it('links tasks', async () => {
+    const aResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Task A', priority: 'p1' },
+    }) as ToolResult;
+    const a = parseResult(aResult) as { id: string };
+
+    const bResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Task B', priority: 'p1' },
+    }) as ToolResult;
+    const b = parseResult(bResult) as { id: string };
+
+    // A is blocked by B
+    const depResult = await client.callTool({
+      name      : 'task_add_dependency',
+      arguments : { taskId: a.id, dependsOn: b.id },
+    }) as ToolResult;
+
+    expect(depResult.isError).toBeUndefined();
+    const parsed = parseResult(depResult) as { success: boolean; taskId: string; dependsOn: string };
+    expect(parsed.success).toBe(true);
+
+    // Verify dependency
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: a.id },
+    }) as ToolResult;
+    const detail = parseResult(showResult) as { dependencies: { tags: { targetId: string } }[] };
+    expect(detail.dependencies.length).toBe(1);
+    expect(detail.dependencies[0].tags.targetId).toBe(b.id);
+  }, 30_000);
+
+  it('detects cycles and returns error', async () => {
+    const aResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Cycle A', priority: 'p1' },
+    }) as ToolResult;
+    const a = parseResult(aResult) as { id: string };
+
+    const bResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Cycle B', priority: 'p1' },
+    }) as ToolResult;
+    const b = parseResult(bResult) as { id: string };
+
+    // A is blocked by B
+    await client.callTool({
+      name      : 'task_add_dependency',
+      arguments : { taskId: a.id, dependsOn: b.id },
+    });
+
+    // Try to add B blocked by A — should detect cycle
+    const cycleResult = await client.callTool({
+      name      : 'task_add_dependency',
+      arguments : { taskId: b.id, dependsOn: a.id },
+    }) as ToolResult;
+
+    expect(cycleResult.isError).toBe(true);
+    const errorText = cycleResult.content[0].text;
+    expect(errorText).toContain('Cycle detected');
+  }, 30_000);
+});
+
+describe('task tools — task_ready', () => {
+  it('returns unblocked tasks', async () => {
+    const collection = `ready-${Date.now()}`;
+
+    // Create two tasks in a unique collection
+    const freeResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Free task', priority: 'p1', collection },
+    }) as ToolResult;
+    const free = parseResult(freeResult) as { id: string };
+
+    const blockerResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Blocker', priority: 'p1', collection },
+    }) as ToolResult;
+    const blocker = parseResult(blockerResult) as { id: string };
+
+    const blockedResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Blocked', priority: 'p1', collection },
+    }) as ToolResult;
+    const blocked = parseResult(blockedResult) as { id: string };
+
+    // blocked depends on blocker
+    await client.callTool({
+      name      : 'task_add_dependency',
+      arguments : { taskId: blocked.id, dependsOn: blocker.id },
+    });
+
+    const readyResult = await client.callTool({
+      name      : 'task_ready',
+      arguments : { collection },
+    }) as ToolResult;
+
+    const ready = parseResult(readyResult) as { id: string }[];
+    const readyIds = ready.map((r) => r.id);
+
+    // free should be ready, blocker should be ready, blocked should NOT
+    expect(readyIds).toContain(free.id);
+    expect(readyIds).toContain(blocker.id);
+    expect(readyIds).not.toContain(blocked.id);
+  }, 30_000);
+});
+
+describe('task tools — task_show', () => {
+  it('returns full detail', async () => {
+    const createResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Show me', priority: 'p2', description: 'A detailed task' },
+    }) as ToolResult;
+    const created = parseResult(createResult) as { id: string };
+
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: created.id },
+    }) as ToolResult;
+
+    expect(showResult.isError).toBeUndefined();
+    const detail = parseResult(showResult) as {
+      id: string;
+      data: { title: string; description: string };
+      tags: { status: string; priority: string };
+      subtasks: unknown[];
+      dependencies: unknown[];
+      notes: unknown[];
+    };
+
+    expect(detail.id).toBe(created.id);
+    expect(detail.data.title).toBe('Show me');
+    expect(detail.data.description).toBe('A detailed task');
+    expect(detail.tags.status).toBe('open');
+    expect(detail.tags.priority).toBe('p2');
+    expect(detail.subtasks).toEqual([]);
+    expect(detail.dependencies).toEqual([]);
+    expect(detail.notes).toEqual([]);
+  }, 30_000);
+});
+
+describe('task tools — task_list', () => {
+  it('lists tasks with filters', async () => {
+    const collection = `list-${Date.now()}`;
+
+    await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'P0 item', priority: 'p0', collection },
+    });
+    await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'P3 item', priority: 'p3', collection },
+    });
+
+    const listResult = await client.callTool({
+      name      : 'task_list',
+      arguments : { priority: 'p0', collection },
+    }) as ToolResult;
+
+    expect(listResult.isError).toBeUndefined();
+    const list = parseResult(listResult) as { records: { tags: { priority: string } }[] };
+    expect(list.records.length).toBeGreaterThanOrEqual(1);
+    for (const r of list.records) {
+      expect(r.tags.priority).toBe('p0');
+    }
+  }, 30_000);
+});
+
+describe('task tools — task_add_note', () => {
+  it('annotates a task', async () => {
+    const createResult = await client.callTool({
+      name      : 'task_create',
+      arguments : { title: 'Note task', priority: 'p1' },
+    }) as ToolResult;
+    const created = parseResult(createResult) as { id: string };
+
+    const noteResult = await client.callTool({
+      name      : 'task_add_note',
+      arguments : { taskId: created.id, content: 'This is a note' },
+    }) as ToolResult;
+
+    expect(noteResult.isError).toBeUndefined();
+    const parsed = parseResult(noteResult) as { success: boolean };
+    expect(parsed.success).toBe(true);
+
+    // Verify note was added
+    const showResult = await client.callTool({
+      name      : 'task_show',
+      arguments : { taskId: created.id },
+    }) as ToolResult;
+    const detail = parseResult(showResult) as { notes: { data: { content: string } }[] };
+    expect(detail.notes.length).toBe(1);
+    expect(detail.notes[0].data.content).toBe('This is a note');
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Registers 7 MCP tools for task graph operations via `registerTaskTools()`:
  - **`task_create`** — create a task or subtask (with parentTaskId for nesting)
  - **`task_update`** — update task fields or atomically claim with `claim: true`
  - **`task_add_dependency`** — link tasks with cycle detection via graph engine
  - **`task_ready`** — list unblocked tasks ready to work on
  - **`task_show`** — full task detail with subtasks, dependencies, notes, status history
  - **`task_list`** — filtered task listing with pagination
  - **`task_add_note`** — annotate a task with notes
- Each tool uses Zod v4 schemas for input validation, returns structured JSON, writes audit log records when configured, and handles errors gracefully
- Cycle detection in `task_add_dependency` prevents circular dependencies before writing to DWN
- 11 integration tests using MCP Client SDK over HTTP transport
- Barrel exports from `src/mcp/index.ts` and `src/index.ts`

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 146 tests pass (11 new)
- `bun run lint` — zero warnings

Closes #12