### PR TITLE
feat: add MCP resources and prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,3 +51,9 @@ export type { MemorydServerOptions } from './mcp/server.js';
 
 export { registerMemoryTools } from './mcp/tools/memory-tools.js';
 export { registerTaskTools } from './mcp/tools/task-tools.js';
+
+export { registerMemoryResources } from './mcp/resources/memory-resources.js';
+export { registerTaskResources } from './mcp/resources/task-resources.js';
+
+export { registerContextPrompt } from './mcp/prompts/context-prompt.js';
+export { registerPlanPrompt } from './mcp/prompts/plan-prompt.js';

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,3 +5,9 @@ export type { MemorydServerOptions } from './server.js';
 
 export { registerMemoryTools } from './tools/memory-tools.js';
 export { registerTaskTools } from './tools/task-tools.js';
+
+export { registerMemoryResources } from './resources/memory-resources.js';
+export { registerTaskResources } from './resources/task-resources.js';
+
+export { registerContextPrompt } from './prompts/context-prompt.js';
+export { registerPlanPrompt } from './prompts/plan-prompt.js';

--- a/src/mcp/prompts/context-prompt.ts
+++ b/src/mcp/prompts/context-prompt.ts
@@ -1,0 +1,46 @@
+// MCP prompt — injects relevant memories for the current conversation.
+
+import { z } from 'zod';
+
+import type { MemorydServer } from '../server.js';
+import type { MemoryStore } from '../../core/memory-store.js';
+
+// ---------------------------------------------------------------------------
+// registerContextPrompt
+// ---------------------------------------------------------------------------
+
+export function registerContextPrompt(
+  server: MemorydServer,
+  memoryStore: MemoryStore,
+): void {
+  server.mcp.registerPrompt(
+    'context',
+    {
+      description : 'Inject relevant memories for the current conversation.',
+      argsSchema  : {
+        topic: z.string().optional().describe('Focus topic for memory retrieval'),
+      },
+    },
+    async ({ topic }) => {
+      const facts = await memoryStore.listFacts(
+        topic ? { category: topic } : undefined,
+        { limit: 20 },
+      );
+
+      const lines = facts.records.map(
+        (f) => `- [${f.tags.category}] ${f.data.content}`,
+      );
+
+      const text = lines.length > 0
+        ? `Here are relevant memories for this user:\n\n${lines.join('\n')}`
+        : 'No memories found for this user yet.';
+
+      return {
+        messages: [{
+          role    : 'user' as const,
+          content : { type: 'text' as const, text },
+        }],
+      };
+    },
+  );
+}

--- a/src/mcp/prompts/index.ts
+++ b/src/mcp/prompts/index.ts
@@ -1,0 +1,2 @@
+export { registerContextPrompt } from './context-prompt.js';
+export { registerPlanPrompt } from './plan-prompt.js';

--- a/src/mcp/prompts/plan-prompt.ts
+++ b/src/mcp/prompts/plan-prompt.ts
@@ -1,0 +1,39 @@
+// MCP prompt — task decomposition template for dependency-aware planning.
+
+import { z } from 'zod';
+
+import type { MemorydServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// registerPlanPrompt
+// ---------------------------------------------------------------------------
+
+export function registerPlanPrompt(
+  server: MemorydServer,
+): void {
+  server.mcp.registerPrompt(
+    'plan',
+    {
+      description : 'Task decomposition template for dependency-aware planning.',
+      argsSchema  : {
+        goal: z.string().describe('The goal to decompose into tasks'),
+      },
+    },
+    async ({ goal }) => ({
+      messages: [{
+        role    : 'user' as const,
+        content : {
+          type : 'text' as const,
+          text : [
+            'Break down the following goal into a dependency-aware task graph.',
+            'For each task, specify title, priority (p0-p3), type, and any dependencies on other tasks.',
+            '',
+            `Goal: ${goal}`,
+            '',
+            'Respond with a structured plan using the task_create and task_add_dependency tools.',
+          ].join('\n'),
+        },
+      }],
+    }),
+  );
+}

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -1,0 +1,2 @@
+export { registerMemoryResources } from './memory-resources.js';
+export { registerTaskResources } from './task-resources.js';

--- a/src/mcp/resources/memory-resources.ts
+++ b/src/mcp/resources/memory-resources.ts
@@ -1,0 +1,49 @@
+// MCP resources — registers memory-related resources on the MCP server.
+
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { MemorydServer } from '../server.js';
+import type { MemoryStore } from '../../core/memory-store.js';
+
+// ---------------------------------------------------------------------------
+// registerMemoryResources
+// ---------------------------------------------------------------------------
+
+export function registerMemoryResources(
+  server: MemorydServer,
+  memoryStore: MemoryStore,
+): void {
+  // -------------------------------------------------------------------------
+  // memory://facts — list all facts
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerResource(
+    'facts-list',
+    'memory://facts',
+    { description: 'List all facts' },
+    async (uri) => ({
+      contents: [{
+        uri      : uri.href,
+        mimeType : 'application/json',
+        text     : JSON.stringify((await memoryStore.listFacts()).records),
+      }],
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // memory://facts/{id} — single fact by ID
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerResource(
+    'fact-by-id',
+    new ResourceTemplate('memory://facts/{id}', { list: undefined }),
+    { description: 'A single fact by ID' },
+    async (uri, { id }) => ({
+      contents: [{
+        uri      : uri.href,
+        mimeType : 'application/json',
+        text     : JSON.stringify(await memoryStore.getFact(id as string)),
+      }],
+    }),
+  );
+}

--- a/src/mcp/resources/task-resources.ts
+++ b/src/mcp/resources/task-resources.ts
@@ -1,0 +1,68 @@
+// MCP resources — registers task-related resources on the MCP server.
+
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { GraphEngine } from '../../core/graph.js';
+import type { MemorydServer } from '../server.js';
+import type { TaskStore } from '../../core/task-store.js';
+
+// ---------------------------------------------------------------------------
+// registerTaskResources
+// ---------------------------------------------------------------------------
+
+export function registerTaskResources(
+  server: MemorydServer,
+  taskStore: TaskStore,
+  graphEngine: GraphEngine,
+): void {
+  // -------------------------------------------------------------------------
+  // memory://tasks — list all tasks
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerResource(
+    'tasks-list',
+    'memory://tasks',
+    { description: 'List all tasks' },
+    async (uri) => ({
+      contents: [{
+        uri      : uri.href,
+        mimeType : 'application/json',
+        text     : JSON.stringify((await taskStore.listTasks()).records),
+      }],
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // memory://tasks/ready — list ready tasks
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerResource(
+    'tasks-ready',
+    'memory://tasks/ready',
+    { description: 'List tasks that are ready to work on (all blockers resolved)' },
+    async (uri) => ({
+      contents: [{
+        uri      : uri.href,
+        mimeType : 'application/json',
+        text     : JSON.stringify(await graphEngine.getReadyTasks()),
+      }],
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // memory://tasks/{id} — single task detail
+  // -------------------------------------------------------------------------
+
+  server.mcp.registerResource(
+    'task-by-id',
+    new ResourceTemplate('memory://tasks/{id}', { list: undefined }),
+    { description: 'Full detail of a single task by ID' },
+    async (uri, { id }) => ({
+      contents: [{
+        uri      : uri.href,
+        mimeType : 'application/json',
+        text     : JSON.stringify(await taskStore.getTask(id as string)),
+      }],
+    }),
+  );
+}

--- a/tests/mcp/prompts/prompts.spec.ts
+++ b/tests/mcp/prompts/prompts.spec.ts
@@ -1,0 +1,140 @@
+import { rmSync } from 'node:fs';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { MemorydServer } from '../../../src/mcp/server.js';
+import { MemoryStore } from '../../../src/core/memory-store.js';
+import { registerContextPrompt } from '../../../src/mcp/prompts/context-prompt.js';
+import { registerPlanPrompt } from '../../../src/mcp/prompts/plan-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/prompts';
+
+let server: MemorydServer;
+let client: Client;
+let memoryStore: MemoryStore;
+let port: number;
+
+beforeAll(async () => {
+  rmSync(DATA_PATH, { recursive: true, force: true });
+
+  const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+  await agent.initialize({ password: 'test' });
+  await agent.start({ password: 'test' });
+
+  const identities = await agent.identity.list();
+  let identity = identities[0];
+  if (!identity) {
+    identity = await agent.identity.create({
+      didMethod  : 'dht',
+      metadata   : { name: 'Test' },
+      didOptions : {
+        verificationMethods: [
+          { algorithm: 'Ed25519', purposes: ['authentication', 'assertionMethod'] },
+          { algorithm: 'X25519', purposes: ['keyAgreement'] },
+        ],
+      },
+    });
+  }
+
+  const result = await Web5.connect({
+    agent,
+    connectedDid : identity.did.uri,
+    sync         : 'off',
+  });
+
+  memoryStore = new MemoryStore(result.web5);
+
+  server = new MemorydServer({ port: 0 });
+  registerContextPrompt(server, memoryStore);
+  registerPlanPrompt(server);
+  const httpResult = await server.startHttp();
+  port = httpResult.port;
+
+  client = new Client({ name: 'test-client', version: '0.1.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/mcp`),
+  );
+  await client.connect(transport);
+}, 30_000);
+
+afterAll(async () => {
+  await client?.close();
+  await server?.stop();
+  rmSync(DATA_PATH, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt listing
+// ---------------------------------------------------------------------------
+
+describe('MCP prompts — listing', () => {
+  it('lists context and plan prompts', async () => {
+    const { prompts } = await client.listPrompts();
+    const names = prompts.map((p) => p.name);
+
+    expect(names).toContain('context');
+    expect(names).toContain('plan');
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// context prompt
+// ---------------------------------------------------------------------------
+
+describe('MCP prompts — context', () => {
+  it('returns "No memories" message when no facts exist', async () => {
+    const result = await client.getPrompt({ name: 'context', arguments: {} });
+
+    expect(result.messages.length).toBe(1);
+    expect(result.messages[0].role).toBe('user');
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain('No memories found');
+  }, 30_000);
+
+  it('returns memories after adding facts', async () => {
+    await memoryStore.addFact('User likes Bun runtime', 'technical', 'agent');
+    await memoryStore.addFact('User prefers dark mode', 'technical', 'user');
+
+    const result = await client.getPrompt({
+      name      : 'context',
+      arguments : { topic: 'technical' },
+    });
+
+    expect(result.messages.length).toBe(1);
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain('relevant memories');
+    expect(text).toContain('Bun runtime');
+    expect(text).toContain('dark mode');
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// plan prompt
+// ---------------------------------------------------------------------------
+
+describe('MCP prompts — plan', () => {
+  it('returns decomposition template with the goal', async () => {
+    const result = await client.getPrompt({
+      name      : 'plan',
+      arguments : { goal: 'Build a REST API' },
+    });
+
+    expect(result.messages.length).toBe(1);
+    expect(result.messages[0].role).toBe('user');
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain('Build a REST API');
+    expect(text).toContain('dependency-aware task graph');
+    expect(text).toContain('task_create');
+  }, 30_000);
+});

--- a/tests/mcp/resources/resources.spec.ts
+++ b/tests/mcp/resources/resources.spec.ts
@@ -1,0 +1,152 @@
+import { rmSync } from 'node:fs';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { GraphEngine } from '../../../src/core/graph.js';
+import { MemorydServer } from '../../../src/mcp/server.js';
+import { MemoryStore } from '../../../src/core/memory-store.js';
+import { registerMemoryResources } from '../../../src/mcp/resources/memory-resources.js';
+import { registerTaskResources } from '../../../src/mcp/resources/task-resources.js';
+import { TaskStore } from '../../../src/core/task-store.js';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/resources';
+
+let server: MemorydServer;
+let client: Client;
+let memoryStore: MemoryStore;
+let taskStore: TaskStore;
+let port: number;
+
+beforeAll(async () => {
+  rmSync(DATA_PATH, { recursive: true, force: true });
+
+  const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+  await agent.initialize({ password: 'test' });
+  await agent.start({ password: 'test' });
+
+  const identities = await agent.identity.list();
+  let identity = identities[0];
+  if (!identity) {
+    identity = await agent.identity.create({
+      didMethod  : 'dht',
+      metadata   : { name: 'Test' },
+      didOptions : {
+        verificationMethods: [
+          { algorithm: 'Ed25519', purposes: ['authentication', 'assertionMethod'] },
+          { algorithm: 'X25519', purposes: ['keyAgreement'] },
+        ],
+      },
+    });
+  }
+
+  const result = await Web5.connect({
+    agent,
+    connectedDid : identity.did.uri,
+    sync         : 'off',
+  });
+
+  memoryStore = new MemoryStore(result.web5);
+  taskStore = new TaskStore(result.web5);
+  const graphEngine = new GraphEngine(taskStore);
+
+  server = new MemorydServer({ port: 0 });
+  registerMemoryResources(server, memoryStore);
+  registerTaskResources(server, taskStore, graphEngine);
+  const httpResult = await server.startHttp();
+  port = httpResult.port;
+
+  client = new Client({ name: 'test-client', version: '0.1.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${port}/mcp`),
+  );
+  await client.connect(transport);
+}, 30_000);
+
+afterAll(async () => {
+  await client?.close();
+  await server?.stop();
+  rmSync(DATA_PATH, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Resource listing
+// ---------------------------------------------------------------------------
+
+describe('MCP resources — listing', () => {
+  it('lists registered resources', async () => {
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri);
+
+    expect(uris).toContain('memory://facts');
+    expect(uris).toContain('memory://tasks');
+    expect(uris).toContain('memory://tasks/ready');
+  }, 30_000);
+
+  it('lists registered resource templates', async () => {
+    const { resourceTemplates } = await client.listResourceTemplates();
+    const uriTemplates = resourceTemplates.map((t) => t.uriTemplate);
+
+    expect(uriTemplates).toContain('memory://facts/{id}');
+    expect(uriTemplates).toContain('memory://tasks/{id}');
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Memory resources
+// ---------------------------------------------------------------------------
+
+describe('MCP resources — memory://facts', () => {
+  it('returns empty list initially', async () => {
+    const result = await client.readResource({ uri: 'memory://facts' });
+    const parsed = JSON.parse(result.contents[0].text as string);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(0);
+  }, 30_000);
+
+  it('returns a fact after adding one via store', async () => {
+    const addResult = await memoryStore.addFact(
+      'TypeScript is great', 'technical', 'user',
+    );
+
+    const result = await client.readResource({
+      uri: `memory://facts/${addResult.id}`,
+    });
+    const parsed = JSON.parse(result.contents[0].text as string);
+
+    expect(parsed.id).toBe(addResult.id);
+    expect(parsed.data.content).toBe('TypeScript is great');
+    expect(parsed.tags.category).toBe('technical');
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Task resources
+// ---------------------------------------------------------------------------
+
+describe('MCP resources — memory://tasks', () => {
+  it('returns empty list initially', async () => {
+    const result = await client.readResource({ uri: 'memory://tasks' });
+    const parsed = JSON.parse(result.contents[0].text as string);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(0);
+  }, 30_000);
+
+  it('returns empty ready tasks initially', async () => {
+    const result = await client.readResource({ uri: 'memory://tasks/ready' });
+    const parsed = JSON.parse(result.contents[0].text as string);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(0);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Registers 5 MCP resources for memory and task data access:
  - **`memory://facts`** — list all facts
  - **`memory://facts/{id}`** — single fact by record ID
  - **`memory://tasks`** — list all tasks
  - **`memory://tasks/ready`** — unblocked tasks via graph engine
  - **`memory://tasks/{id}`** — full task detail with subtasks, dependencies, notes, status history
- Registers 2 MCP prompt templates:
  - **`context`** — injects relevant memories into conversation context, with optional `topic` focus
  - **`plan`** — task decomposition template for dependency-aware planning, accepts a `goal` argument
- 10 integration tests using MCP Client SDK over HTTP
- Barrel exports from `src/mcp/index.ts` and `src/index.ts`

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 163 tests pass (10 new)
- `bun run lint` — zero warnings

Closes #13