### PR TITLE
feat: add memory compaction engine

### DIFF
--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -1,0 +1,257 @@
+// ---------------------------------------------------------------------------
+// CompactionEngine — memory compaction/decay for the memoryd memory store.
+// Archives stale superseded facts, merges near-duplicates, and vacuums the
+// sidecar database.
+// ---------------------------------------------------------------------------
+
+import type { Database } from 'bun:sqlite';
+
+import type { MemoryStore } from './memory-store.js';
+import type { SearchIndex } from '../sidecar/search.js';
+import type { TaskStore } from './task-store.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Configuration for compaction operations. */
+export type CompactionConfig = {
+  /** Days before superseded facts are archived (default: 30). */
+  ageThresholdDays : number;
+  /** Cosine similarity threshold for merging duplicates (default: 0.95). */
+  similarityThreshold : number;
+  /** Maximum number of facts to retain (default: 10000). */
+  maxFactCount : number;
+};
+
+/** Result of a compaction run. */
+export type CompactionResult = {
+  /** Count of superseded facts older than threshold that were archived. */
+  archivedStale : number;
+  /** Count of near-duplicate facts that were merged. */
+  mergedDuplicates : number;
+  /** Whether the sidecar database was vacuumed. */
+  vacuumed : boolean;
+};
+
+/** Injected summarisation function — merges multiple fact contents into one. */
+export type SummarizeFn = (facts: string[]) => Promise<string>;
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIG: CompactionConfig = {
+  ageThresholdDays    : 30,
+  similarityThreshold : 0.95,
+  maxFactCount        : 10000,
+};
+
+// ---------------------------------------------------------------------------
+// Internal row type for sqlite-vec distance queries
+// ---------------------------------------------------------------------------
+
+type EmbeddingRow = {
+  record_id : string;
+  content_preview : string;
+  distance : number;
+};
+
+// ---------------------------------------------------------------------------
+// CompactionEngine
+// ---------------------------------------------------------------------------
+
+export class CompactionEngine {
+  private readonly memoryStore : MemoryStore;
+  private readonly _taskStore : TaskStore;
+  private readonly sidecarDb? : Database;
+  private readonly searchIndex? : SearchIndex;
+  private readonly summarize? : SummarizeFn;
+
+  constructor(
+    memoryStore : MemoryStore,
+    taskStore : TaskStore,
+    opts?: {
+      sidecarDb? : Database;
+      searchIndex? : SearchIndex;
+      summarize? : SummarizeFn;
+    },
+  ) {
+    this.memoryStore = memoryStore;
+    this._taskStore = taskStore;
+    this.sidecarDb = opts?.sidecarDb;
+    this.searchIndex = opts?.searchIndex;
+    this.summarize = opts?.summarize;
+  }
+
+  // -------------------------------------------------------------------------
+  // archiveStale — archive superseded facts older than threshold
+  // -------------------------------------------------------------------------
+
+  async archiveStale(config?: Partial<CompactionConfig>): Promise<number> {
+    const { ageThresholdDays } = { ...DEFAULT_CONFIG, ...config };
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - ageThresholdDays);
+    const cutoffIso = cutoff.toISOString();
+
+    // Fetch all superseded facts
+    const { records } = await this.memoryStore.listFacts({ status: 'superseded' });
+
+    let archived = 0;
+    for (const fact of records) {
+      // Only archive facts older than the threshold
+      if (fact.dateCreated < cutoffIso) {
+        await this.memoryStore.updateFact(fact.id, { status: 'archived' });
+        archived++;
+      }
+    }
+
+    return archived;
+  }
+
+  // -------------------------------------------------------------------------
+  // mergeRedundant — find near-duplicate facts via vector similarity
+  // -------------------------------------------------------------------------
+
+  async mergeRedundant(
+    config?: Partial<CompactionConfig>,
+    summarize?: SummarizeFn,
+  ): Promise<number> {
+    const effectiveSummarize = summarize ?? this.summarize;
+
+    if (!this.sidecarDb) {
+      return 0;
+    }
+    if (!effectiveSummarize) {
+      return 0;
+    }
+
+    const { similarityThreshold } = { ...DEFAULT_CONFIG, ...config };
+
+    // Query all active fact embeddings from the sidecar
+    const rows = this.sidecarDb.prepare(`
+      SELECT record_id, content_preview
+      FROM memory_embeddings
+    `).all() as Array<{ record_id: string; content_preview: string }>;
+
+    if (rows.length < 2) {
+      return 0;
+    }
+
+    // For each record, find near-duplicates via KNN and group them
+    const merged = new Set<string>();
+    let mergeCount = 0;
+
+    for (const row of rows) {
+      if (merged.has(row.record_id)) {
+        continue;
+      }
+
+      // Get this record's embedding
+      const embeddingRow = this.sidecarDb.prepare(`
+        SELECT embedding FROM memory_embeddings WHERE record_id = ?
+      `).get(row.record_id) as { embedding: Float32Array } | null;
+
+      if (!embeddingRow) {
+        continue;
+      }
+
+      // Find similar records using sqlite-vec KNN
+      const similar = this.sidecarDb.prepare(`
+        SELECT record_id, content_preview, distance
+        FROM memory_embeddings
+        WHERE embedding MATCH ?
+          AND k = ?
+      `).all(embeddingRow.embedding, rows.length) as EmbeddingRow[];
+
+      // Cosine distance: 0 = identical, 2 = opposite.
+      // Threshold is similarity (0.95), so distance threshold = 1 - similarity.
+      const distanceThreshold = 1 - similarityThreshold;
+
+      // Group candidates that are below distance threshold
+      const group: Array<{ recordId: string; content: string }> = [];
+      for (const s of similar) {
+        if (s.record_id === row.record_id) {
+          continue;
+        }
+        if (merged.has(s.record_id)) {
+          continue;
+        }
+        if (s.distance <= distanceThreshold) {
+          group.push({ recordId: s.record_id, content: s.content_preview });
+        }
+      }
+
+      if (group.length === 0) {
+        continue;
+      }
+
+      // Include the current record in the group
+      group.unshift({ recordId: row.record_id, content: row.content_preview });
+
+      // Summarize the group into a single fact
+      const contents = group.map(g => g.content);
+      const summary = await effectiveSummarize(contents);
+
+      // Use supersedeFact on the first record as the base, then supersede the rest
+      const baseId = group[0].recordId;
+      const newResult = await this.memoryStore.supersedeFact(baseId, summary, {
+        reason: 'Compaction: merged near-duplicate facts',
+      });
+
+      // Mark the remaining group members as superseded
+      for (let i = 1; i < group.length; i++) {
+        await this.memoryStore.supersedeFact(group[i].recordId, summary, {
+          reason: 'Compaction: merged near-duplicate facts',
+        });
+        merged.add(group[i].recordId);
+      }
+
+      merged.add(baseId);
+
+      // Update the search index if available
+      if (this.searchIndex) {
+        for (const g of group) {
+          this.searchIndex.remove(g.recordId);
+        }
+        await this.searchIndex.upsert({
+          recordId     : newResult.id,
+          protocolPath : 'memory/v1/fact',
+          content      : summary,
+        });
+      }
+
+      mergeCount += group.length;
+    }
+
+    return mergeCount;
+  }
+
+  // -------------------------------------------------------------------------
+  // vacuumSidecar — run VACUUM on the sidecar database
+  // -------------------------------------------------------------------------
+
+  vacuumSidecar(): boolean {
+    if (!this.sidecarDb) {
+      return false;
+    }
+    this.sidecarDb.exec('VACUUM');
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // compact — run all compaction operations in sequence
+  // -------------------------------------------------------------------------
+
+  async compact(
+    config?: Partial<CompactionConfig>,
+    summarize?: SummarizeFn,
+  ): Promise<CompactionResult> {
+    const archivedStale = await this.archiveStale(config);
+    const mergedDuplicates = await this.mergeRedundant(config, summarize);
+    const vacuumed = this.vacuumSidecar();
+
+    return { archivedStale, mergedDuplicates, vacuumed };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ export type { TaskTreeNode } from './core/graph.js';
 export { ConsentManager } from './core/consent.js';
 export type { AgentRecord, AgentRegistration, AgentScope, AuditLogRecord } from './core/consent.js';
 
+export { CompactionEngine } from './core/compaction.js';
+export type { CompactionConfig, CompactionResult, SummarizeFn } from './core/compaction.js';
+
 export type { EmbeddingConfig, EmbeddingProvider } from './sidecar/embeddings.js';
 export { createEmbeddingProvider, NoopProvider, OllamaProvider, OpenAIProvider } from './sidecar/embeddings.js';
 

--- a/src/mcp/tools/memory-tools.ts
+++ b/src/mcp/tools/memory-tools.ts
@@ -1,6 +1,7 @@
 // memoryd MCP tools — memory_add_fact, memory_add_preference, memory_search,
 // memory_supersede, memory_compact.
 
+import type { CompactionEngine } from '../../core/compaction.js';
 import type { MemorydServer } from '../server.js';
 import type { MemoryStore } from '../../core/memory-store.js';
 import type { SearchIndex } from '../../sidecar/search.js';
@@ -66,6 +67,7 @@ export function registerMemoryTools(
   memoryStore: MemoryStore,
   searchIndex?: SearchIndex,
   auditTyped?: AuditTyped,
+  compactionEngine?: CompactionEngine,
 ): void {
   // -----------------------------------------------------------------------
   // memory_add_fact
@@ -203,15 +205,28 @@ export function registerMemoryTools(
   // -----------------------------------------------------------------------
 
   server.mcp.registerTool('memory_compact', {
-    description : 'Compact the memory store by merging or pruning old entries. (Not yet implemented — see Issue #15.)',
+    description : 'Compact the memory store by archiving stale facts, merging near-duplicates, and vacuuming the sidecar.',
     inputSchema : {
-      olderThan  : z.string().optional().describe('ISO 8601 date — compact records older than this date.'),
-      collection : z.string().optional().describe('Limit compaction to a specific collection.'),
+      ageThresholdDays    : z.number().int().min(0).default(30).describe('Archive superseded facts older than this many days.'),
+      similarityThreshold : z.number().min(0).max(1).default(0.95).describe('Cosine similarity threshold for merging duplicates.'),
     },
-  }, async (_args) => {
-    return jsonResult({
-      status  : 'not_implemented',
-      message : 'Memory compaction is not yet implemented. See Issue #15.',
-    });
+  }, async (args) => {
+    try {
+      if (!compactionEngine) {
+        return jsonResult({ status: 'not_configured', message: 'Compaction engine not configured.' });
+      }
+      const result = await compactionEngine.compact({
+        ageThresholdDays    : args.ageThresholdDays,
+        similarityThreshold : args.similarityThreshold,
+      });
+      await writeAudit(
+        auditTyped, 'memory_compact',
+        `Compacted: archived=${result.archivedStale} merged=${result.mergedDuplicates} vacuumed=${result.vacuumed}`,
+        'compaction',
+      );
+      return jsonResult(result);
+    } catch (err) {
+      return errorResult(err);
+    }
   });
 }

--- a/tests/core/compaction.spec.ts
+++ b/tests/core/compaction.spec.ts
@@ -1,0 +1,297 @@
+import { rmSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { CompactionEngine } from '../../src/core/compaction.js';
+import { MemoryProtocol } from '../../src/protocols/memory.js';
+import { MemoryStore } from '../../src/core/memory-store.js';
+import { SearchIndex } from '../../src/sidecar/search.js';
+import { SidecarDatabase } from '../../src/sidecar/database.js';
+import { TaskGraphProtocol } from '../../src/protocols/task-graph.js';
+import { TaskStore } from '../../src/core/task-store.js';
+
+import type { EmbeddingProvider } from '../../src/sidecar/embeddings.js';
+import type { SummarizeFn } from '../../src/core/compaction.js';
+
+const DATA_PATH = '__TESTDATA__/compaction';
+const DIMS = 4;
+
+// ---------------------------------------------------------------------------
+// Test embedding provider — returns predictable non-zero vectors
+// ---------------------------------------------------------------------------
+
+class TestEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions = DIMS;
+  private vectorMap = new Map<string, number[]>();
+
+  /** Register a known vector for specific content. */
+  setVector(content: string, vector: number[]): void {
+    this.vectorMap.set(content, vector);
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const known = this.vectorMap.get(text);
+    if (known) {
+      return known;
+    }
+    // Default: hash-based deterministic vector
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+      hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+    }
+    return [
+      Math.sin(hash) * 0.5 + 0.5,
+      Math.cos(hash) * 0.5 + 0.5,
+      Math.sin(hash * 2) * 0.5 + 0.5,
+      Math.cos(hash * 2) * 0.5 + 0.5,
+    ];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return Promise.all(texts.map(t => this.embed(t)));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CompactionEngine tests
+// ---------------------------------------------------------------------------
+
+describe('CompactionEngine', () => {
+  let memoryStore: MemoryStore;
+  let taskStore: TaskStore;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test' });
+    await agent.start({ password: 'test' });
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Test' },
+        didOptions : {
+          verificationMethods: [
+            {
+              algorithm : 'Ed25519',
+              id        : 'sig',
+              purposes  : ['assertionMethod', 'authentication'],
+            },
+            {
+              algorithm : 'X25519',
+              id        : 'enc',
+              purposes  : ['keyAgreement'],
+            },
+          ],
+        },
+      });
+    }
+    const { web5 } = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    // Configure protocols
+    const memoryTyped = web5.using(MemoryProtocol);
+    await memoryTyped.configure({ encryption: true });
+
+    const taskTyped = web5.using(TaskGraphProtocol);
+    await taskTyped.configure({ encryption: true });
+
+    memoryStore = new MemoryStore(web5);
+    taskStore = new TaskStore(web5);
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // archiveStale
+  // -------------------------------------------------------------------------
+
+  describe('archiveStale', () => {
+    it('returns 0 when no superseded facts exist', async () => {
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      const count = await engine.archiveStale({ ageThresholdDays: 0 });
+      expect(count).toBe(0);
+    });
+
+    it('archives a superseded fact when threshold is 0 days', async () => {
+      // Create a fact and supersede it
+      const original = await memoryStore.addFact(
+        'Stale fact to archive', 'compaction-test', 'user',
+      );
+      await memoryStore.supersedeFact(original.id, 'Replacement fact');
+
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      const count = await engine.archiveStale({ ageThresholdDays: 0 });
+      expect(count).toBeGreaterThanOrEqual(1);
+
+      // Verify the fact was actually archived
+      const fact = await memoryStore.getFact(original.id);
+      expect(fact.tags.status).toBe('archived');
+    });
+
+    it('respects age threshold — recent superseded facts are not archived', async () => {
+      // Create and supersede a fact (it will be very recent)
+      const original = await memoryStore.addFact(
+        'Recent superseded fact', 'compaction-age-test', 'user',
+      );
+      await memoryStore.supersedeFact(original.id, 'Replacement');
+
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      // Use a large threshold — the fact was just created, so it's newer than 365 days
+      const count = await engine.archiveStale({ ageThresholdDays: 365 });
+      expect(count).toBe(0);
+
+      // Verify the fact is still superseded, not archived
+      const fact = await memoryStore.getFact(original.id);
+      expect(fact.tags.status).toBe('superseded');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // mergeRedundant
+  // -------------------------------------------------------------------------
+
+  describe('mergeRedundant', () => {
+    it('returns 0 without sidecar', async () => {
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      const mockSummarize: SummarizeFn = async (facts) => facts.join('; ');
+      const count = await engine.mergeRedundant({}, mockSummarize);
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 without summarize function', async () => {
+      const sidecar = new SidecarDatabase(':memory:', DIMS);
+      try {
+        const engine = new CompactionEngine(memoryStore, taskStore, {
+          sidecarDb: sidecar.db,
+        });
+        const count = await engine.mergeRedundant();
+        expect(count).toBe(0);
+      } finally {
+        sidecar.close();
+      }
+    });
+
+    it('merges near-duplicate facts when sidecar and summarize are provided', async () => {
+      const embeddings = new TestEmbeddingProvider();
+      const sidecar = new SidecarDatabase(':memory:', DIMS);
+
+      try {
+        const searchIndex = new SearchIndex(sidecar.db, embeddings);
+
+        // Create two facts with similar content
+        const fact1 = await memoryStore.addFact(
+          'The user likes TypeScript', 'merge-test', 'user',
+        );
+        const fact2 = await memoryStore.addFact(
+          'User enjoys TypeScript programming', 'merge-test', 'user',
+        );
+
+        // Set identical vectors so they appear as near-duplicates
+        const sameVector = [0.5, 0.5, 0.5, 0.5];
+        embeddings.setVector('The user likes TypeScript', sameVector);
+        embeddings.setVector('User enjoys TypeScript programming', sameVector);
+
+        // Index both facts in the sidecar
+        await searchIndex.upsert({
+          recordId     : fact1.id,
+          protocolPath : 'memory/v1/fact',
+          content      : 'The user likes TypeScript',
+          category     : 'merge-test',
+        });
+        await searchIndex.upsert({
+          recordId     : fact2.id,
+          protocolPath : 'memory/v1/fact',
+          content      : 'User enjoys TypeScript programming',
+          category     : 'merge-test',
+        });
+
+        let summarizeCalled = false;
+        const mockSummarize: SummarizeFn = async (facts) => {
+          summarizeCalled = true;
+          return `Merged: ${facts.join(' + ')}`;
+        };
+
+        const engine = new CompactionEngine(memoryStore, taskStore, {
+          sidecarDb : sidecar.db,
+          searchIndex,
+          summarize : mockSummarize,
+        });
+
+        const count = await engine.mergeRedundant({ similarityThreshold: 0.95 });
+        expect(count).toBeGreaterThanOrEqual(2);
+        expect(summarizeCalled).toBe(true);
+
+        // Verify original facts are now superseded
+        const f1 = await memoryStore.getFact(fact1.id);
+        expect(f1.tags.status).toBe('superseded');
+        const f2 = await memoryStore.getFact(fact2.id);
+        expect(f2.tags.status).toBe('superseded');
+      } finally {
+        sidecar.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vacuumSidecar
+  // -------------------------------------------------------------------------
+
+  describe('vacuumSidecar', () => {
+    it('returns false without sidecar', () => {
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      expect(engine.vacuumSidecar()).toBe(false);
+    });
+
+    it('returns true when sidecar is available', () => {
+      const sidecar = new SidecarDatabase(':memory:', DIMS);
+      try {
+        const engine = new CompactionEngine(memoryStore, taskStore, {
+          sidecarDb: sidecar.db,
+        });
+        expect(engine.vacuumSidecar()).toBe(true);
+      } finally {
+        sidecar.close();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // compact
+  // -------------------------------------------------------------------------
+
+  describe('compact', () => {
+    it('returns combined result from all operations', async () => {
+      const engine = new CompactionEngine(memoryStore, taskStore);
+      const result = await engine.compact();
+
+      expect(typeof result.archivedStale).toBe('number');
+      expect(typeof result.mergedDuplicates).toBe('number');
+      expect(result.vacuumed).toBe(false); // no sidecar
+    });
+
+    it('compact with sidecar vacuums successfully', async () => {
+      const sidecar = new SidecarDatabase(':memory:', DIMS);
+      try {
+        const engine = new CompactionEngine(memoryStore, taskStore, {
+          sidecarDb: sidecar.db,
+        });
+        const result = await engine.compact();
+
+        expect(result.vacuumed).toBe(true);
+        expect(typeof result.archivedStale).toBe('number');
+        expect(result.mergedDuplicates).toBe(0); // no summarize fn
+      } finally {
+        sidecar.close();
+      }
+    });
+  });
+});

--- a/tests/mcp/tools/memory-tools.spec.ts
+++ b/tests/mcp/tools/memory-tools.spec.ts
@@ -198,10 +198,10 @@ describe('memory tools (MCP)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // memory_compact — stub
+  // memory_compact — not configured (no compaction engine)
   // -------------------------------------------------------------------------
 
-  it('memory_compact returns not-yet-implemented message', async () => {
+  it('memory_compact returns not-configured when no compaction engine', async () => {
     const result = await client.callTool({
       name      : 'memory_compact',
       arguments : {},
@@ -209,8 +209,8 @@ describe('memory tools (MCP)', () => {
 
     expect(result.isError).toBeFalsy();
     const parsed = JSON.parse((result.content as { type: string; text: string }[])[0].text);
-    expect(parsed.status).toBe('not_implemented');
-    expect(parsed.message).toContain('not yet implemented');
+    expect(parsed.status).toBe('not_configured');
+    expect(parsed.message).toContain('not configured');
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements `CompactionEngine` class for semantic memory decay:
  - **`archiveStale`** — archives superseded facts older than configurable age threshold (default 30 days)
  - **`mergeRedundant`** — detects near-duplicate facts via sidecar embedding similarity (cosine distance), merges with injected summarize function, supersedes originals
  - **`vacuumSidecar`** — runs SQLite VACUUM after bulk operations
  - **`compact`** — orchestrates all three operations, returns `CompactionResult`
- Wires up the `memory_compact` MCP tool to use CompactionEngine when configured (returns `not_configured` status otherwise)
- Summarize function is injected (not hardcoded LLM) — tests use a mock, real usage passes an LLM call
- 9 integration tests with mock summarize function and real sidecar

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 198 tests pass (9 new)
- `bun run lint` — zero warnings

Closes #15