### PR TITLE
feat: add agent consent management

### DIFF
--- a/src/cli/commands/revoke.ts
+++ b/src/cli/commands/revoke.ts
@@ -1,0 +1,21 @@
+// memoryd CLI — revoke command: revoke agent consent.
+
+import type { AgentContext } from '../agent.js';
+
+export async function revokeCommand(ctx: AgentContext, args: string[]): Promise<void> {
+  const agentDid = args.find(a => !a.startsWith('--'));
+  if (!agentDid) {
+    console.error('Usage: memoryd revoke <agent-did>');
+    process.exit(1);
+  }
+
+  const { ConsentManager } = await import('../../core/consent.js');
+  const manager = new ConsentManager(ctx.web5);
+  const revoked = await manager.revokeAgent(agentDid);
+
+  if (revoked) {
+    console.log(`Agent ${agentDid} revoked successfully.`);
+  } else {
+    console.log(`No agent found with DID: ${agentDid}`);
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -27,6 +27,7 @@ Commands:
   task dep add <child> <parent> Add dependency
   task note <id> <content>      Add a note
 
+  revoke <agent-did>            Revoke agent consent
   compact                       Compact memory store
   audit                         Show audit log
 
@@ -88,6 +89,11 @@ async function main(): Promise<void> {
     }
     case 'compact': {
       console.log('Memory compaction is not yet implemented. See Issue #15.');
+      break;
+    }
+    case 'revoke': {
+      const { revokeCommand } = await import('./commands/revoke.js');
+      await revokeCommand(ctx, rest);
       break;
     }
     case 'audit': {

--- a/src/core/consent.ts
+++ b/src/core/consent.ts
@@ -1,0 +1,248 @@
+import type { ActionLogData } from '../protocols/audit.js';
+import type { PaginationCursor, ProtocolDefinition } from '@enbox/dwn-sdk-js';
+import type { SchemaMap, TypedProtocol, TypedWeb5, Web5 } from '@enbox/api';
+
+import { AuditProtocol } from '../protocols/audit.js';
+import { DateSort } from '@enbox/dwn-sdk-js';
+import { MemoryProtocol } from '../protocols/memory.js';
+
+// ---------------------------------------------------------------------------
+// Extract definition and schema map types from the typed protocols
+// ---------------------------------------------------------------------------
+
+type InferDef<P> = P extends TypedProtocol<infer D, infer _M> ? D : ProtocolDefinition;
+type InferMap<P> = P extends TypedProtocol<infer _D, infer M> ? M : SchemaMap;
+
+type MemoryDef = InferDef<typeof MemoryProtocol>;
+type MemoryMap = InferMap<typeof MemoryProtocol>;
+type MemoryTyped = TypedWeb5<MemoryDef, MemoryMap>;
+
+type AuditDef = InferDef<typeof AuditProtocol>;
+type AuditMap = InferMap<typeof AuditProtocol>;
+type AuditTyped = TypedWeb5<AuditDef, AuditMap>;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type AgentScope = {
+  protocol : string;
+  path : string;
+  actions : string[];
+};
+
+export type AgentRegistration = {
+  did : string;
+  name : string;
+  description? : string;
+  scopes : AgentScope[];
+  grantedAt : string;
+};
+
+export type AgentRecord = {
+  id : string;
+  data : AgentRegistration;
+  dateCreated : string;
+};
+
+export type AuditLogRecord = {
+  id : string;
+  data : ActionLogData;
+  tags : {
+    agentDid : string;
+    action : string;
+    targetProtocol : string;
+    targetRecordId : string;
+    status : string;
+  };
+  dateCreated : string;
+};
+
+// ---------------------------------------------------------------------------
+// Internal tag record alias
+// ---------------------------------------------------------------------------
+
+type TagRecord = Record<string, string | number | boolean | string[] | number[]>;
+
+// ---------------------------------------------------------------------------
+// ConsentManager
+// ---------------------------------------------------------------------------
+
+export class ConsentManager {
+  private readonly memoryTyped : MemoryTyped;
+  private readonly auditTyped : AuditTyped;
+  private memoryConfigured = false;
+  private auditConfigured = false;
+
+  constructor(web5: Web5) {
+    this.memoryTyped = web5.using(MemoryProtocol);
+    this.auditTyped = web5.using(AuditProtocol);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  private async ensureMemoryConfigured(): Promise<void> {
+    if (!this.memoryConfigured) {
+      await this.memoryTyped.configure({ encryption: true });
+      this.memoryConfigured = true;
+    }
+  }
+
+  private async ensureAuditConfigured(): Promise<void> {
+    if (!this.auditConfigured) {
+      await this.auditTyped.configure();
+      this.auditConfigured = true;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Agent registration
+  // -------------------------------------------------------------------------
+
+  async registerAgent(agentDid: string, name: string, opts?: {
+    description? : string;
+    scopes? : AgentScope[];
+  }): Promise<AgentRecord> {
+    await this.ensureMemoryConfigured();
+
+    const now = new Date().toISOString();
+    const registration: AgentRegistration = {
+      did         : agentDid,
+      name,
+      description : opts?.description,
+      scopes      : opts?.scopes ?? [],
+      grantedAt   : now,
+    };
+
+    const { status, record } = await this.memoryTyped.records.create('fact', {
+      data       : { content: JSON.stringify(registration) },
+      tags       : { category: '_agent', source: 'system', status: 'active' },
+      encryption : true,
+    });
+
+    if (status.code !== 202) {
+      throw new Error(`registerAgent failed: ${status.code} ${status.detail}`);
+    }
+
+    return {
+      id          : record.id,
+      data        : registration,
+      dateCreated : record.dateCreated,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Listing agents
+  // -------------------------------------------------------------------------
+
+  async listAgents(): Promise<AgentRecord[]> {
+    await this.ensureMemoryConfigured();
+
+    const { status, records } = await this.memoryTyped.records.query('fact', {
+      filter     : { tags: { category: '_agent', source: 'system', status: 'active' } },
+      dateSort   : DateSort.CreatedDescending,
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`listAgents failed: ${status.code} ${status.detail}`);
+    }
+
+    const results: AgentRecord[] = [];
+    for (const record of records) {
+      const raw = await record.data.json() as { content: string };
+      const registration = JSON.parse(raw.content) as AgentRegistration;
+      results.push({
+        id          : record.id,
+        data        : registration,
+        dateCreated : record.dateCreated,
+      });
+    }
+
+    return results;
+  }
+
+  // -------------------------------------------------------------------------
+  // Get single agent
+  // -------------------------------------------------------------------------
+
+  async getAgent(agentDid: string): Promise<AgentRecord | undefined> {
+    const agents = await this.listAgents();
+    return agents.find(a => a.data.did === agentDid);
+  }
+
+  // -------------------------------------------------------------------------
+  // Revoking agents
+  // -------------------------------------------------------------------------
+
+  async revokeAgent(agentDid: string): Promise<boolean> {
+    await this.ensureMemoryConfigured();
+
+    const { status, records } = await this.memoryTyped.records.query('fact', {
+      filter     : { tags: { category: '_agent', source: 'system', status: 'active' } },
+      dateSort   : DateSort.CreatedDescending,
+      encryption : true,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`revokeAgent query failed: ${status.code} ${status.detail}`);
+    }
+
+    let revoked = false;
+    for (const record of records) {
+      const raw = await record.data.json() as { content: string };
+      const registration = JSON.parse(raw.content) as AgentRegistration;
+      if (registration.did === agentDid) {
+        const { status: delStatus } = await this.memoryTyped.records.delete('fact', {
+          recordId: record.id,
+        });
+        if (delStatus.code !== 202) {
+          throw new Error(`revokeAgent delete failed: ${delStatus.code} ${delStatus.detail}`);
+        }
+        revoked = true;
+      }
+    }
+
+    return revoked;
+  }
+
+  // -------------------------------------------------------------------------
+  // Audit log queries
+  // -------------------------------------------------------------------------
+
+  async getAgentAuditLog(agentDid: string, limit?: number): Promise<AuditLogRecord[]> {
+    await this.ensureAuditConfigured();
+
+    const { status, records } = await this.auditTyped.records.query('actionLog', {
+      filter     : { tags: { agentDid } },
+      dateSort   : DateSort.CreatedDescending,
+      pagination : limit ? { limit } as { limit: number; cursor?: PaginationCursor } : undefined,
+    });
+
+    if (status.code !== 200) {
+      throw new Error(`getAgentAuditLog failed: ${status.code} ${status.detail}`);
+    }
+
+    const results: AuditLogRecord[] = [];
+    for (const record of records) {
+      const data = await record.data.json() as ActionLogData;
+      const tags = record.tags as TagRecord | undefined;
+      results.push({
+        id   : record.id,
+        data,
+        tags : {
+          agentDid       : tags?.agentDid as string,
+          action         : tags?.action as string,
+          targetProtocol : tags?.targetProtocol as string,
+          targetRecordId : tags?.targetRecordId as string,
+          status         : tags?.status as string,
+        },
+        dateCreated: record.dateCreated,
+      });
+    }
+
+    return results;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export type {
 export { GraphEngine } from './core/graph.js';
 export type { TaskTreeNode } from './core/graph.js';
 
+export { ConsentManager } from './core/consent.js';
+export type { AgentRecord, AgentRegistration, AgentScope, AuditLogRecord } from './core/consent.js';
+
 export type { EmbeddingConfig, EmbeddingProvider } from './sidecar/embeddings.js';
 export { createEmbeddingProvider, NoopProvider, OllamaProvider, OpenAIProvider } from './sidecar/embeddings.js';
 

--- a/tests/core/consent.spec.ts
+++ b/tests/core/consent.spec.ts
@@ -1,0 +1,175 @@
+import { rmSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { ConsentManager } from '../../src/core/consent.js';
+import { MemoryProtocol } from '../../src/protocols/memory.js';
+
+const DATA_PATH = '__TESTDATA__/consent';
+
+describe('ConsentManager', () => {
+  let manager: ConsentManager;
+  let web5: Web5;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test' });
+    await agent.start({ password: 'test' });
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Test' },
+        didOptions : {
+          verificationMethods: [
+            {
+              algorithm : 'Ed25519',
+              id        : 'sig',
+              purposes  : ['assertionMethod', 'authentication'],
+            },
+            {
+              algorithm : 'X25519',
+              id        : 'enc',
+              purposes  : ['keyAgreement'],
+            },
+          ],
+        },
+      });
+    }
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    web5 = result.web5;
+
+    // Configure protocol with encryption
+    const typed = web5.using(MemoryProtocol);
+    await typed.configure({ encryption: true });
+
+    manager = new ConsentManager(web5);
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // registerAgent
+  // -------------------------------------------------------------------------
+
+  it('registerAgent stores agent metadata and returns AgentRecord', async () => {
+    const record = await manager.registerAgent('did:dht:agent1', 'TestAgent', {
+      description : 'A test agent',
+      scopes      : [{ protocol: 'memory/v1', path: 'fact', actions: ['read'] }],
+    });
+
+    expect(record.id).toBeDefined();
+    expect(typeof record.id).toBe('string');
+    expect(record.data.did).toBe('did:dht:agent1');
+    expect(record.data.name).toBe('TestAgent');
+    expect(record.data.description).toBe('A test agent');
+    expect(record.data.scopes).toHaveLength(1);
+    expect(record.data.scopes[0].protocol).toBe('memory/v1');
+    expect(record.data.grantedAt).toBeDefined();
+    expect(record.dateCreated).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // listAgents
+  // -------------------------------------------------------------------------
+
+  it('listAgents returns registered agents', async () => {
+    const agents = await manager.listAgents();
+    expect(agents.length).toBeGreaterThanOrEqual(1);
+    const found = agents.find(a => a.data.did === 'did:dht:agent1');
+    expect(found).toBeDefined();
+    expect(found!.data.name).toBe('TestAgent');
+  });
+
+  it('listAgents returns empty when no agents registered', async () => {
+    // Create a fresh ConsentManager against same web5 — but first revoke all
+    const agents = await manager.listAgents();
+    const dids = new Set(agents.map(a => a.data.did));
+    for (const did of dids) {
+      await manager.revokeAgent(did);
+    }
+    const result = await manager.listAgents();
+    expect(result).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // revokeAgent
+  // -------------------------------------------------------------------------
+
+  it('revokeAgent removes an agent and returns true', async () => {
+    // Register a fresh agent
+    await manager.registerAgent('did:dht:revokeme', 'RevokeTest');
+    const revoked = await manager.revokeAgent('did:dht:revokeme');
+    expect(revoked).toBe(true);
+
+    // Verify it's gone
+    const agent = await manager.getAgent('did:dht:revokeme');
+    expect(agent).toBeUndefined();
+  });
+
+  it('revokeAgent returns false for unknown DID', async () => {
+    const revoked = await manager.revokeAgent('did:dht:unknown');
+    expect(revoked).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Register, revoke, list lifecycle
+  // -------------------------------------------------------------------------
+
+  it('register then revoke then list shows agent removed', async () => {
+    await manager.registerAgent('did:dht:lifecycle', 'LifecycleAgent', {
+      scopes: [
+        { protocol: 'memory/v1', path: '*', actions: ['*'] },
+        { protocol: 'task-graph/v1', path: 'task', actions: ['create', 'read'] },
+      ],
+    });
+
+    // Verify it's listed
+    let agents = await manager.listAgents();
+    expect(agents.find(a => a.data.did === 'did:dht:lifecycle')).toBeDefined();
+
+    // Revoke
+    const revoked = await manager.revokeAgent('did:dht:lifecycle');
+    expect(revoked).toBe(true);
+
+    // Verify it's gone
+    agents = await manager.listAgents();
+    expect(agents.find(a => a.data.did === 'did:dht:lifecycle')).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // getAgent
+  // -------------------------------------------------------------------------
+
+  it('getAgent returns undefined for unknown DID', async () => {
+    const agent = await manager.getAgent('did:dht:nonexistent');
+    expect(agent).toBeUndefined();
+  });
+
+  it('getAgent returns agent record for registered DID', async () => {
+    await manager.registerAgent('did:dht:getme', 'GetMeAgent');
+    const agent = await manager.getAgent('did:dht:getme');
+    expect(agent).toBeDefined();
+    expect(agent!.data.did).toBe('did:dht:getme');
+    expect(agent!.data.name).toBe('GetMeAgent');
+  });
+
+  // -------------------------------------------------------------------------
+  // getAgentAuditLog
+  // -------------------------------------------------------------------------
+
+  it('getAgentAuditLog returns empty for unknown agent', async () => {
+    const logs = await manager.getAgentAuditLog('did:dht:nologs');
+    expect(logs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `ConsentManager` class for agent registration and revocation:
  - **`registerAgent`** — stores agent metadata (DID, name, description, scopes) as specially-tagged facts
  - **`listAgents`** / **`getAgent`** — queries registered agents
  - **`revokeAgent`** — deletes all registration records for an agent DID
  - **`getAgentAuditLog`** — filters audit log by agent DID
- Adds `memoryd revoke <agent-did>` CLI command
- Updates CLI usage text with revoke command
- 9 integration tests with real Web5UserAgent

## Quality gates

- `bun run build` — zero errors
- `bun test .spec.ts` — 197 tests pass (9 new)
- `bun run lint` — zero warnings

Closes #16