### PR TITLE
feat: shared Enbox identity management (profiles)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@enbox/memoryd",
       "dependencies": {
+        "@clack/prompts": "^1.0.1",
         "@enbox/api": "0.3.0",
         "@enbox/crypto": "0.0.6",
         "@enbox/dids": "0.0.7",
@@ -69,6 +70,10 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@clack/core": ["@clack/core@1.0.1", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g=="],
+
+    "@clack/prompts": ["@clack/prompts@1.0.1", "", { "dependencies": { "@clack/core": "1.0.1", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q=="],
 
     "@decentralized-identity/ion-sdk": ["@decentralized-identity/ion-sdk@1.0.4", "", { "dependencies": { "@noble/ed25519": "^2.0.0", "@noble/secp256k1": "^2.0.0", "canonicalize": "^2.0.0", "multiformats": "^12.1.3", "uri-js": "^4.4.1" } }, "sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A=="],
 
@@ -675,6 +680,8 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
+    "@clack/prompts": "^1.0.1",
     "@enbox/api": "0.3.0",
     "@enbox/crypto": "0.0.6",
     "@enbox/dids": "0.0.7",

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1,4 +1,15 @@
-// memoryd CLI — bootstrap Web5 agent and return an AgentContext.
+/**
+ * Agent bootstrapping — connects to (or creates) a local Web5 agent.
+ *
+ * On first run the agent vault is initialized with a password, a DID is
+ * created, and the memory protocols are installed.  Subsequent runs unlock
+ * the existing vault and return a ready-to-use context with stores.
+ *
+ * Agent data is stored under the resolved profile path:
+ *   `~/.enbox/profiles/<profile>/DATA/AGENT/`
+ *
+ * @module
+ */
 
 import type { GraphEngine } from '../core/graph.js';
 import type { MemoryStore } from '../core/memory-store.js';
@@ -7,29 +18,123 @@ import type { SidecarDatabase } from '../sidecar/database.js';
 import type { TaskStore } from '../core/task-store.js';
 import type { Web5 } from '@enbox/api';
 
-export type AgentContext = {
-  did: string;
-  web5: Web5;
-  memoryStore: MemoryStore;
-  taskStore: TaskStore;
-  graphEngine: GraphEngine;
-  sidecarDb?: SidecarDatabase;
-  searchIndex?: SearchIndex;
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for connecting to the agent. */
+export type ConnectOptions = {
+  /** Vault password. */
+  password : string;
+  /**
+   * Agent data path.  When provided, the agent stores all data under
+   * this directory instead of the default `DATA/AGENT` relative to CWD.
+   *
+   * The profile system sets this to `~/.enbox/profiles/<name>/DATA/AGENT`.
+   */
+  dataPath? : string;
+  /**
+   * Optional recovery phrase (12-word BIP-39 mnemonic) for initializing
+   * a new vault.  When omitted, a new phrase is generated automatically.
+   */
+  recoveryPhrase? : string;
 };
 
-export async function connectAgent(password: string): Promise<AgentContext> {
-  const { Web5: Web5Cls } = await import('@enbox/api');
-  const { web5, did, recoveryPhrase } = await Web5Cls.connect({ password, sync: 'off' });
+/** Context returned by `connectAgent()` — provides stores and engines. */
+export type AgentContext = {
+  did : string;
+  web5 : Web5;
+  memoryStore : MemoryStore;
+  taskStore : TaskStore;
+  graphEngine : GraphEngine;
+  sidecarDb? : SidecarDatabase;
+  searchIndex? : SearchIndex;
+  recoveryPhrase? : string;
+};
 
-  if (recoveryPhrase) {
-    console.log('');
-    console.log('=== RECOVERY PHRASE (save this!) ===');
-    console.log(recoveryPhrase);
-    console.log('===================================');
-    console.log('');
+// ---------------------------------------------------------------------------
+// Agent bootstrap
+// ---------------------------------------------------------------------------
+
+/**
+ * Connect to the local Web5 agent, initializing on first launch.
+ *
+ * When `dataPath` is provided, the agent's persistent data lives there.
+ * Otherwise, it falls back to `DATA/AGENT` relative to CWD (legacy).
+ *
+ * Sync is disabled — the CLI operates against the local DWN only.
+ */
+export async function connectAgent(options: ConnectOptions): Promise<AgentContext> {
+  const { password, dataPath, recoveryPhrase: inputPhrase } = options;
+
+  let web5: Web5;
+  let did: string;
+  let recoveryPhrase: string | undefined;
+
+  if (dataPath) {
+    // Profile-based: create agent with explicit data path.
+    const { Web5UserAgent } = await import('@enbox/agent');
+    const agent = await Web5UserAgent.create({ dataPath });
+
+    if (await agent.firstLaunch()) {
+      recoveryPhrase = await agent.initialize({
+        password,
+        recoveryPhrase : inputPhrase,
+        dwnEndpoints   : ['https://enbox-dwn.fly.dev'],
+      });
+    }
+    await agent.start({ password });
+
+    // Ensure at least one identity exists.
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod  : 'dht',
+        metadata   : { name: 'Default' },
+        didOptions : {
+          services: [{
+            id              : 'dwn',
+            type            : 'DecentralizedWebNode',
+            serviceEndpoint : ['https://enbox-dwn.fly.dev'],
+            enc             : '#enc',
+            sig             : '#sig',
+          }],
+          verificationMethods: [
+            { algorithm: 'Ed25519', id: 'sig', purposes: ['assertionMethod', 'authentication'] },
+            { algorithm: 'X25519', id: 'enc', purposes: ['keyAgreement'] },
+          ],
+        },
+      });
+    }
+
+    const { Web5: Web5Cls } = await import('@enbox/api');
+    const result = await Web5Cls.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    web5 = result.web5;
+    did = result.did;
+  } else {
+    // Legacy: let Web5.connect() manage the agent (uses CWD-relative path).
+    const { Web5: Web5Cls } = await import('@enbox/api');
+    const result = await Web5Cls.connect({ password, sync: 'off' });
+
+    web5 = result.web5;
+    did = result.did;
+    recoveryPhrase = result.recoveryPhrase;
+
+    if (recoveryPhrase) {
+      console.log('');
+      console.log('  Recovery phrase (save this — it cannot be shown again):');
+      console.log(`  ${recoveryPhrase}`);
+      console.log('');
+    }
   }
 
-  // Import dynamically to avoid importing heavy modules at parse time
+  // Import dynamically to avoid importing heavy modules at parse time.
   const { MemoryStore: MS } = await import('../core/memory-store.js');
   const { TaskStore: TS } = await import('../core/task-store.js');
   const { GraphEngine: GE } = await import('../core/graph.js');
@@ -38,5 +143,5 @@ export async function connectAgent(password: string): Promise<AgentContext> {
   const taskStore = new TS(web5);
   const graphEngine = new GE(taskStore);
 
-  return { did, web5, memoryStore, taskStore, graphEngine };
+  return { did, web5, memoryStore, taskStore, graphEngine, recoveryPhrase };
 }

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,288 @@
+/**
+ * `memoryd auth` — identity and profile management.
+ *
+ * Usage:
+ *   memoryd auth                          Show current identity info
+ *   memoryd auth login                    Create or import an identity
+ *   memoryd auth list                     List all profiles
+ *   memoryd auth use <profile>            Set profile for current repo
+ *   memoryd auth use <profile> --global   Set default profile
+ *   memoryd auth logout [profile]         Remove a profile
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../agent.js';
+
+import * as p from '@clack/prompts';
+
+import { connectAgent } from '../agent.js';
+import {
+  enboxHome,
+  listProfiles,
+  profileDataPath,
+  readConfig,
+  resolveProfile,
+  setGitConfigProfile,
+  upsertProfile,
+  writeConfig,
+} from '../../profiles/config.js';
+
+// ---------------------------------------------------------------------------
+// Sub-command dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * The auth command can run without a pre-existing AgentContext (for `login`,
+ * `list`), but some sub-commands need one (for info display).  We accept
+ * ctx as optional and connect lazily when needed.
+ */
+export async function authCommand(ctx: AgentContext | null, args: string[]): Promise<void> {
+  const sub = args[0];
+
+  switch (sub) {
+    case 'login': return authLogin();
+    case 'list': return authList();
+    case 'use': return authUse(args.slice(1));
+    case 'logout': return authLogout(args.slice(1));
+    default: return authInfo(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// auth (no subcommand) — show current identity
+// ---------------------------------------------------------------------------
+
+async function authInfo(ctx: AgentContext | null): Promise<void> {
+  const config = readConfig();
+  const profileName = resolveProfile();
+
+  if (!profileName || !config.profiles[profileName]) {
+    p.log.warn('No identity configured. Run `memoryd auth login` to get started.');
+    return;
+  }
+
+  const entry = config.profiles[profileName];
+
+  p.log.info(`Profile:    ${profileName}${config.defaultProfile === profileName ? ' (default)' : ''}`);
+  p.log.info(`DID:        ${entry.did}`);
+  p.log.info(`Created:    ${entry.createdAt}`);
+  p.log.info(`Data:       ${profileDataPath(profileName)}`);
+
+  if (ctx) {
+    p.log.info(`Connected:  ${ctx.did}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// auth login — create or import identity
+// ---------------------------------------------------------------------------
+
+async function authLogin(): Promise<void> {
+  p.intro('Identity setup');
+
+  const action = await p.select({
+    message : 'What would you like to do?',
+    options : [
+      { value: 'create', label: 'Create a new identity' },
+      { value: 'import', label: 'Import from recovery phrase' },
+    ],
+  });
+
+  if (p.isCancel(action)) {
+    p.cancel('Cancelled.');
+    return;
+  }
+
+  const name = await p.text({
+    message     : 'Name this profile:',
+    placeholder : 'personal',
+    validate(val) {
+      if (!val?.trim()) { return 'Profile name is required.'; }
+      if (!/^[a-zA-Z0-9_-]+$/.test(val)) { return 'Only letters, numbers, hyphens, and underscores.'; }
+      const existing = listProfiles();
+      if (existing.includes(val)) { return `Profile "${val}" already exists.`; }
+    },
+  });
+
+  if (p.isCancel(name)) {
+    p.cancel('Cancelled.');
+    return;
+  }
+
+  const profileName = (name as string).trim();
+
+  const password = await p.password({
+    message: 'Choose a password for your vault:',
+    validate(val) {
+      if (!val || (val as string).length < 4) { return 'Password must be at least 4 characters.'; }
+    },
+  });
+
+  if (p.isCancel(password)) {
+    p.cancel('Cancelled.');
+    return;
+  }
+
+  let recoveryInput: string | undefined;
+
+  if (action === 'import') {
+    const phrase = await p.text({
+      message     : 'Enter your 12-word recovery phrase:',
+      placeholder : 'abandon ability able about above absent ...',
+      validate(val) {
+        if (!val) { return 'Recovery phrase is required.'; }
+        const words = val.trim().split(/\s+/);
+        if (words.length !== 12) { return 'Recovery phrase must be exactly 12 words.'; }
+      },
+    });
+
+    if (p.isCancel(phrase)) {
+      p.cancel('Cancelled.');
+      return;
+    }
+
+    recoveryInput = (phrase as string).trim();
+  }
+
+  const spin = p.spinner();
+  spin.start('Creating identity...');
+
+  try {
+    const dataPath = profileDataPath(profileName);
+    const result = await connectAgent({
+      password       : password as string,
+      dataPath,
+      recoveryPhrase : recoveryInput,
+    });
+
+    // Save profile metadata.
+    upsertProfile(profileName, {
+      name      : profileName,
+      did       : result.did,
+      createdAt : new Date().toISOString(),
+    });
+
+    spin.stop('Identity created!');
+
+    p.log.success(`DID:     ${result.did}`);
+    p.log.success(`Profile: ${profileName} (${dataPath})`);
+
+    if (result.recoveryPhrase) {
+      p.log.warn('');
+      p.log.warn('Your recovery phrase (write this down!):');
+      p.log.warn(`  ${result.recoveryPhrase}`);
+      p.log.warn('');
+      p.log.warn('This phrase can recover your identity if you lose your password.');
+      p.log.warn('Store it securely — it will NOT be shown again.');
+    }
+  } catch (err) {
+    spin.stop('Failed.');
+    p.log.error(`Failed to create identity: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  p.outro('You\'re all set! Run `memoryd auth` to verify.');
+}
+
+// ---------------------------------------------------------------------------
+// auth list — list all profiles
+// ---------------------------------------------------------------------------
+
+function authList(): void {
+  const config = readConfig();
+  const names = Object.keys(config.profiles);
+
+  if (names.length === 0) {
+    p.log.warn('No profiles found. Run `memoryd auth login` to create one.');
+    return;
+  }
+
+  p.log.info(`Profiles (${enboxHome()}):\n`);
+
+  for (const name of names) {
+    const entry = config.profiles[name];
+    const isDefault = config.defaultProfile === name ? '  (default)' : '';
+    p.log.info(`  ${name}${isDefault}`);
+    p.log.info(`    DID:     ${entry.did}`);
+    p.log.info(`    Created: ${entry.createdAt}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// auth use — set active profile
+// ---------------------------------------------------------------------------
+
+async function authUse(args: string[]): Promise<void> {
+  const name = args[0];
+  const isGlobal = args.includes('--global');
+
+  if (!name) {
+    p.log.error('Usage: memoryd auth use <profile> [--global]');
+    process.exit(1);
+  }
+
+  const config = readConfig();
+  if (!config.profiles[name]) {
+    p.log.error(`Profile "${name}" not found. Run \`memoryd auth list\` to see available profiles.`);
+    process.exit(1);
+  }
+
+  if (isGlobal) {
+    config.defaultProfile = name;
+    writeConfig(config);
+    p.log.success(`Default profile set to "${name}".`);
+  } else {
+    try {
+      setGitConfigProfile(name);
+      p.log.success(`Profile "${name}" set for this repository.`);
+    } catch {
+      p.log.error('Not in a git repository. Use --global to set the default profile.');
+      process.exit(1);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// auth logout — remove a profile
+// ---------------------------------------------------------------------------
+
+async function authLogout(args: string[]): Promise<void> {
+  let name = args[0];
+
+  if (!name) {
+    name = resolveProfile() ?? '';
+  }
+
+  if (!name) {
+    p.log.error('No profile specified and no default profile found.');
+    process.exit(1);
+  }
+
+  const config = readConfig();
+  if (!config.profiles[name]) {
+    p.log.error(`Profile "${name}" not found.`);
+    process.exit(1);
+  }
+
+  const confirm = await p.confirm({
+    message: `Remove profile "${name}"? This will delete all local data for this identity.`,
+  });
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.cancel('Cancelled.');
+    return;
+  }
+
+  // Remove from config (we don't delete the data directory — user can do that).
+  delete config.profiles[name];
+  if (config.defaultProfile === name) {
+    const remaining = Object.keys(config.profiles);
+    config.defaultProfile = remaining[0] ?? '';
+  }
+  writeConfig(config);
+
+  p.log.success(`Profile "${name}" removed.`);
+  p.log.info(`Data directory preserved at: ${profileDataPath(name)}`);
+  p.log.info('Delete it manually if you want to free disk space.');
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,8 +12,15 @@ function printUsage(): void {
 Usage: memoryd <command> [options]
 
 Commands:
+  auth                          Show current identity info
+  auth login                    Create or import an identity
+  auth list                     List all profiles
+  auth use <profile> [--global] Set active profile
+  auth logout [profile]         Remove a profile
+
   init                          Install protocols and create sidecar DB
   serve                         Start MCP server (HTTP/SSE)
+  whoami                        Print current DID
 
   fact add <content>            Add a fact
   fact list                     List facts
@@ -35,8 +42,57 @@ Options:
   --help, -h     Show help
   --version, -v  Show version
   --json         Output as JSON
-  --password     Agent password (or set MEMORYD_PASSWORD)
+  --profile      Select identity profile
 `);
+}
+
+async function getPassword(): Promise<string> {
+  const env = process.env.MEMORYD_PASSWORD;
+  if (env) { return env; }
+
+  process.stdout.write('Vault password: ');
+
+  if (process.stdin.isTTY) {
+    // Raw mode password input — characters are not echoed.
+    const password = await new Promise<string>((resolve) => {
+      let buf = '';
+      process.stdin.setRawMode(true);
+      process.stdin.setEncoding('utf8');
+      process.stdin.resume();
+      const onData = (ch: string): void => {
+        const code = ch.charCodeAt(0);
+        if (ch === '\r' || ch === '\n') {
+          process.stdin.setRawMode(false);
+          process.stdin.pause();
+          process.stdin.removeListener('data', onData);
+          process.stdout.write('\n');
+          resolve(buf);
+        } else if (code === 3) {
+          process.stdin.setRawMode(false);
+          process.stdout.write('\n');
+          process.exit(130);
+        } else if (code === 127 || code === 8) {
+          if (buf.length > 0) { buf = buf.slice(0, -1); }
+        } else if (code >= 32) {
+          buf += ch;
+        }
+      };
+      process.stdin.on('data', onData);
+    });
+    return password;
+  }
+
+  // Non-TTY fallback (piped stdin).
+  const response = await new Promise<string>((resolve) => {
+    let buf = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.once('data', (chunk: string) => {
+      buf += chunk;
+      resolve(buf.trim());
+    });
+    process.stdin.resume();
+  });
+  return response;
 }
 
 async function main(): Promise<void> {
@@ -44,26 +100,36 @@ async function main(): Promise<void> {
   const command = args[0];
   const rest = args.slice(1);
 
-  // No-agent commands
-  if (!command || command === 'help' || hasFlag(args, '--help') || hasFlag(args, '-h')) {
-    printUsage();
-    return;
-  }
-
+  // No-agent commands: version / help
   if (command === '--version' || command === '-v' || hasFlag(args, '--version')) {
     console.log(VERSION);
     return;
   }
 
-  // Agent-required commands
-  const password = flagValue(rest, '--password') ?? process.env.MEMORYD_PASSWORD;
-  if (!password) {
-    console.error('Error: password required. Use --password <pw> or set MEMORYD_PASSWORD.');
-    process.exit(1);
+  if (!command || command === 'help' || hasFlag(args, '--help') || hasFlag(args, '-h')) {
+    printUsage();
+    return;
   }
 
+  // Commands that don't need agent
+  switch (command) {
+    case 'auth': {
+      const { authCommand } = await import('./commands/auth.js');
+      await authCommand(null, rest);
+      return;
+    }
+  }
+
+  // Commands that need agent
+  const password = await getPassword();
+
+  const { resolveProfile, profileDataPath } = await import('../profiles/config.js');
+  const profileFlag = flagValue(rest, '--profile');
+  const profileName = resolveProfile(profileFlag);
+  const dataPath = profileName ? profileDataPath(profileName) : undefined;
+
   const { connectAgent } = await import('./agent.js');
-  const ctx = await connectAgent(password);
+  const ctx = await connectAgent({ password, dataPath });
   const json = hasFlag(rest, '--json');
 
   switch (command) {
@@ -98,6 +164,10 @@ async function main(): Promise<void> {
     }
     case 'audit': {
       console.log('Audit log viewer is not yet implemented.');
+      break;
+    }
+    case 'whoami': {
+      console.log(ctx.did);
       break;
     }
     default: {

--- a/src/profiles/config.ts
+++ b/src/profiles/config.ts
@@ -1,0 +1,188 @@
+/**
+ * Profile configuration — persistent config at `~/.enbox/config.json`.
+ *
+ * Manages the set of named identity profiles and the default selection.
+ * This module handles reading, writing, and resolving profiles across
+ * multiple selection sources (flag, env, git config, global default).
+ *
+ * Storage layout:
+ *   ~/.enbox/
+ *     config.json               Global config (this module)
+ *     profiles/
+ *       <name>/DATA/AGENT/...   Per-profile Web5 agent stores
+ *
+ * @module
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Base directory for all enbox data.  Override with `ENBOX_HOME`. */
+export function enboxHome(): string {
+  return process.env.ENBOX_HOME ?? join(homedir(), '.enbox');
+}
+
+/** Path to the global config file. */
+export function configPath(): string {
+  return join(enboxHome(), 'config.json');
+}
+
+/** Base directory for all profile agent data. */
+export function profilesDir(): string {
+  return join(enboxHome(), 'profiles');
+}
+
+/** Path to a specific profile's agent data directory. */
+export function profileDataPath(name: string): string {
+  return join(profilesDir(), name, 'DATA', 'AGENT');
+}
+
+// ---------------------------------------------------------------------------
+// Config types
+// ---------------------------------------------------------------------------
+
+/** Metadata about a single profile stored in config.json. */
+export type ProfileEntry = {
+  /** Display name for the profile. */
+  name : string;
+  /** The DID URI associated with this profile. */
+  did : string;
+  /** ISO 8601 timestamp when the profile was created. */
+  createdAt : string;
+};
+
+/** Top-level config.json shape. */
+export type EnboxConfig = {
+  /** Schema version for forward-compatibility. */
+  version : number;
+  /** Name of the default profile. */
+  defaultProfile : string;
+  /** Map of profile name → metadata. */
+  profiles : Record<string, ProfileEntry>;
+};
+
+// ---------------------------------------------------------------------------
+// Config I/O
+// ---------------------------------------------------------------------------
+
+/** Read the global config.  Returns a default if the file doesn't exist. */
+export function readConfig(): EnboxConfig {
+  const path = configPath();
+  if (!existsSync(path)) {
+    return { version: 1, defaultProfile: '', profiles: {} };
+  }
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as EnboxConfig;
+}
+
+/** Write the global config atomically. */
+export function writeConfig(config: EnboxConfig): void {
+  const path = configPath();
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+/** Add or update a profile entry in the global config. */
+export function upsertProfile(name: string, entry: ProfileEntry): void {
+  const config = readConfig();
+  config.profiles[name] = entry;
+
+  // If this is the first profile, make it the default.
+  if (!config.defaultProfile || Object.keys(config.profiles).length === 1) {
+    config.defaultProfile = name;
+  }
+
+  writeConfig(config);
+}
+
+/** Remove a profile entry from the global config. */
+export function removeProfile(name: string): void {
+  const config = readConfig();
+  delete config.profiles[name];
+
+  // If we removed the default, pick the first remaining (or clear).
+  if (config.defaultProfile === name) {
+    const remaining = Object.keys(config.profiles);
+    config.defaultProfile = remaining[0] ?? '';
+  }
+
+  writeConfig(config);
+}
+
+/** List all profile names. */
+export function listProfiles(): string[] {
+  return Object.keys(readConfig().profiles);
+}
+
+// ---------------------------------------------------------------------------
+// Profile resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve which profile to use.
+ *
+ * Precedence (highest to lowest):
+ *   1. `--profile <name>` flag (passed as `flagProfile`)
+ *   2. `ENBOX_PROFILE` environment variable
+ *   3. `.git/config` → `[enbox] profile = <name>`
+ *   4. `~/.enbox/config.json` → `defaultProfile`
+ *   5. First (and only) profile, if exactly one exists
+ *
+ * Returns `null` when no profile can be resolved (i.e. none exist).
+ */
+export function resolveProfile(flagProfile?: string): string | null {
+  // 1. Explicit flag.
+  if (flagProfile) { return flagProfile; }
+
+  // 2. Environment variable.
+  const envProfile = process.env.ENBOX_PROFILE;
+  if (envProfile) { return envProfile; }
+
+  // 3. Per-repo git config.
+  const gitProfile = readGitConfigProfile();
+  if (gitProfile) { return gitProfile; }
+
+  // 4. Global default.
+  const config = readConfig();
+  if (config.defaultProfile) { return config.defaultProfile; }
+
+  // 5. Single profile fallback.
+  const names = Object.keys(config.profiles);
+  if (names.length === 1) { return names[0]; }
+
+  return null;
+}
+
+/**
+ * Read the `[enbox] profile` setting from the current repo's `.git/config`.
+ * Returns `null` if not in a git repo or the setting is absent.
+ */
+function readGitConfigProfile(): string | null {
+  try {
+    const result = spawnSync('git', ['config', '--local', 'enbox.profile'], {
+      stdio   : ['pipe', 'pipe', 'pipe'],
+      timeout : 2_000,
+    });
+    const value = result.stdout?.toString().trim();
+    if (result.status === 0 && value) { return value; }
+  } catch {
+    // Not in a git repo or git not available.
+  }
+  return null;
+}
+
+/**
+ * Write the `[enbox] profile` setting to the current repo's `.git/config`.
+ */
+export function setGitConfigProfile(name: string): void {
+  spawnSync('git', ['config', '--local', 'enbox.profile', name], {
+    stdio   : ['pipe', 'pipe', 'pipe'],
+    timeout : 2_000,
+  });
+}

--- a/tests/profiles/config.spec.ts
+++ b/tests/profiles/config.spec.ts
@@ -1,0 +1,191 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+  configPath,
+  enboxHome,
+  listProfiles,
+  profileDataPath,
+  profilesDir,
+  readConfig,
+  removeProfile,
+  resolveProfile,
+  upsertProfile,
+  writeConfig,
+} from '../../src/profiles/config.js';
+
+// ---------------------------------------------------------------------------
+// Test setup — use a temp directory as ENBOX_HOME
+// ---------------------------------------------------------------------------
+
+const TEST_HOME = join(tmpdir(), `memoryd-config-test-${Date.now()}`);
+let savedEnboxHome: string | undefined;
+let savedEnboxProfile: string | undefined;
+
+beforeAll(() => {
+  savedEnboxHome = process.env.ENBOX_HOME;
+  savedEnboxProfile = process.env.ENBOX_PROFILE;
+  process.env.ENBOX_HOME = TEST_HOME;
+  delete process.env.ENBOX_PROFILE;
+  mkdirSync(TEST_HOME, { recursive: true });
+});
+
+afterAll(() => {
+  if (savedEnboxHome !== undefined) {
+    process.env.ENBOX_HOME = savedEnboxHome;
+  } else {
+    delete process.env.ENBOX_HOME;
+  }
+  if (savedEnboxProfile !== undefined) {
+    process.env.ENBOX_PROFILE = savedEnboxProfile;
+  } else {
+    delete process.env.ENBOX_PROFILE;
+  }
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Clean config between tests.
+  rmSync(TEST_HOME, { recursive: true, force: true });
+  mkdirSync(TEST_HOME, { recursive: true });
+  delete process.env.ENBOX_PROFILE;
+});
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+describe('path helpers', () => {
+  it('enboxHome returns ENBOX_HOME env value', () => {
+    expect(enboxHome()).toBe(TEST_HOME);
+  });
+
+  it('configPath is config.json under enboxHome', () => {
+    expect(configPath()).toBe(join(TEST_HOME, 'config.json'));
+  });
+
+  it('profilesDir is profiles/ under enboxHome', () => {
+    expect(profilesDir()).toBe(join(TEST_HOME, 'profiles'));
+  });
+
+  it('profileDataPath returns correct nested path', () => {
+    expect(profileDataPath('alice')).toBe(join(TEST_HOME, 'profiles', 'alice', 'DATA', 'AGENT'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config I/O
+// ---------------------------------------------------------------------------
+
+describe('readConfig / writeConfig', () => {
+  it('readConfig returns default when no config file exists', () => {
+    const config = readConfig();
+    expect(config.version).toBe(1);
+    expect(config.defaultProfile).toBe('');
+    expect(config.profiles).toEqual({});
+  });
+
+  it('writeConfig + readConfig round-trips', () => {
+    const config = {
+      version        : 1,
+      defaultProfile : 'test',
+      profiles       : {
+        test: { name: 'test', did: 'did:dht:abc', createdAt: '2025-01-01T00:00:00Z' },
+      },
+    };
+    writeConfig(config);
+    const loaded = readConfig();
+    expect(loaded).toEqual(config);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertProfile / removeProfile / listProfiles
+// ---------------------------------------------------------------------------
+
+describe('upsertProfile', () => {
+  it('adds a profile and sets as default if first', () => {
+    upsertProfile('alice', { name: 'alice', did: 'did:dht:alice', createdAt: '2025-01-01T00:00:00Z' });
+    const config = readConfig();
+    expect(config.profiles['alice']).toBeDefined();
+    expect(config.defaultProfile).toBe('alice');
+  });
+
+  it('second profile does not change default', () => {
+    upsertProfile('alice', { name: 'alice', did: 'did:dht:alice', createdAt: '2025-01-01T00:00:00Z' });
+    upsertProfile('bob', { name: 'bob', did: 'did:dht:bob', createdAt: '2025-01-02T00:00:00Z' });
+    const config = readConfig();
+    expect(config.profiles['bob']).toBeDefined();
+    expect(config.defaultProfile).toBe('alice');
+  });
+});
+
+describe('removeProfile', () => {
+  it('removes profile and reassigns default', () => {
+    upsertProfile('alice', { name: 'alice', did: 'did:dht:alice', createdAt: '2025-01-01T00:00:00Z' });
+    upsertProfile('bob', { name: 'bob', did: 'did:dht:bob', createdAt: '2025-01-02T00:00:00Z' });
+    removeProfile('alice');
+    const config = readConfig();
+    expect(config.profiles['alice']).toBeUndefined();
+    expect(config.defaultProfile).toBe('bob');
+  });
+
+  it('clears default when last profile is removed', () => {
+    upsertProfile('only', { name: 'only', did: 'did:dht:only', createdAt: '2025-01-01T00:00:00Z' });
+    removeProfile('only');
+    const config = readConfig();
+    expect(config.defaultProfile).toBe('');
+  });
+});
+
+describe('listProfiles', () => {
+  it('returns profile names', () => {
+    upsertProfile('alice', { name: 'alice', did: 'did:dht:alice', createdAt: '2025-01-01T00:00:00Z' });
+    upsertProfile('bob', { name: 'bob', did: 'did:dht:bob', createdAt: '2025-01-02T00:00:00Z' });
+    const names = listProfiles();
+    expect(names).toContain('alice');
+    expect(names).toContain('bob');
+    expect(names.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveProfile
+// ---------------------------------------------------------------------------
+
+describe('resolveProfile', () => {
+  it('returns explicit flag value when provided', () => {
+    expect(resolveProfile('explicit')).toBe('explicit');
+  });
+
+  it('returns ENBOX_PROFILE env var when set', () => {
+    process.env.ENBOX_PROFILE = 'env-profile';
+    expect(resolveProfile()).toBe('env-profile');
+    delete process.env.ENBOX_PROFILE;
+  });
+
+  it('returns default profile from config', () => {
+    upsertProfile('default-one', { name: 'default-one', did: 'did:dht:d1', createdAt: '2025-01-01T00:00:00Z' });
+    upsertProfile('other', { name: 'other', did: 'did:dht:other', createdAt: '2025-01-02T00:00:00Z' });
+    expect(resolveProfile()).toBe('default-one');
+  });
+
+  it('returns single profile when exactly one exists', () => {
+    // Write config with no default but one profile.
+    writeConfig({
+      version        : 1,
+      defaultProfile : '',
+      profiles       : {
+        lonely: { name: 'lonely', did: 'did:dht:lonely', createdAt: '2025-01-01T00:00:00Z' },
+      },
+    });
+    expect(resolveProfile()).toBe('lonely');
+  });
+
+  it('returns null when no profiles exist', () => {
+    expect(resolveProfile()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the simple `--password` CLI auth with the standardized Enbox profile system, matching the pattern established in gitd. This gives memoryd shared identity management across Enbox tools.

Closes #37

## Changes

- **`src/profiles/config.ts`** — Shared profile config module: CRUD for `~/.enbox/profiles/<name>/`, `config.json` management, 5-level profile resolution (`--profile` flag → `ENBOX_PROFILE` env → `config.json` defaultProfile → single-profile fallback)
- **`src/cli/agent.ts`** — Rewritten to accept `ConnectOptions` with `dataPath` for profile-based agent bootstrap using `Web5UserAgent.create({ dataPath })`, with `did:dht` identity creation (Ed25519 + X25519 keys)
- **`src/cli/main.ts`** — TTY raw-mode password input (no echo), two-tier command dispatch (no-agent commands like `auth` run without unlocking vault), `whoami` command
- **`src/cli/commands/auth.ts`** — Interactive auth commands via `@clack/prompts`: login (create/import profile), list, use (set default), logout (remove profile)
- **`tests/profiles/config.spec.ts`** — 11 tests for profile config module

## Verification

- `bun run build` — Zero TypeScript errors
- `bun test .spec.ts` — 223 tests pass, 0 failures
- `bun run lint` — Zero ESLint warnings/errors