### PR TITLE
chore: add config module and move @enbox/agent to dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@enbox/memoryd",
       "dependencies": {
         "@clack/prompts": "^1.0.1",
+        "@enbox/agent": "0.2.0",
         "@enbox/api": "0.3.0",
         "@enbox/crypto": "0.0.6",
         "@enbox/dids": "0.0.7",
@@ -16,7 +17,6 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
-        "@enbox/agent": "0.2.0",
         "@eslint/js": "9.7.0",
         "@stylistic/eslint-plugin": "^5.9.0",
         "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",
+    "@enbox/agent": "0.2.0",
     "@enbox/api": "0.3.0",
     "@enbox/crypto": "0.0.6",
     "@enbox/dids": "0.0.7",
@@ -67,7 +68,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
-    "@enbox/agent": "0.2.0",
     "@eslint/js": "9.7.0",
     "@stylistic/eslint-plugin": "^5.9.0",
     "@typescript-eslint/eslint-plugin": "8.32.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,85 @@
+/**
+ * Centralized runtime configuration — resolves env vars and defaults.
+ *
+ * All runtime settings are gathered here so that CLI commands and the
+ * MCP server use a single source of truth.
+ *
+ * @module
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { EmbeddingConfig } from './sidecar/embeddings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Resolved runtime configuration. */
+export type MemorydConfig = {
+  /** Path to the sidecar SQLite database. */
+  sidecarPath : string;
+  /** Embedding provider configuration. */
+  embedding : EmbeddingConfig;
+  /** HTTP server host. */
+  host : string;
+  /** HTTP server port. */
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SIDECAR_PATH = join(homedir(), '.memoryd', 'index.db');
+
+// ---------------------------------------------------------------------------
+// Resolve
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link MemorydConfig} from environment variables and defaults.
+ *
+ * | Variable                      | Default                         |
+ * |-------------------------------|---------------------------------|
+ * | `MEMORYD_SIDECAR_PATH`        | `~/.memoryd/index.db`           |
+ * | `MEMORYD_EMBEDDING_PROVIDER`  | `noop`                          |
+ * | `MEMORYD_EMBEDDING_MODEL`     | provider default                |
+ * | `MEMORYD_EMBEDDING_URL`       | `http://localhost:11434` (Ollama) |
+ * | `MEMORYD_EMBEDDING_DIMENSIONS`| provider default                |
+ * | `OPENAI_API_KEY`              | —                               |
+ * | `MEMORYD_HOST`                | `localhost`                     |
+ * | `MEMORYD_PORT`                | `3200`                          |
+ */
+export function resolveConfig(overrides?: Partial<MemorydConfig>): MemorydConfig {
+  const provider = (
+    process.env.MEMORYD_EMBEDDING_PROVIDER ?? 'noop'
+  ) as EmbeddingConfig['provider'];
+
+  const dimensionsRaw = process.env.MEMORYD_EMBEDDING_DIMENSIONS;
+  const dimensions = dimensionsRaw ? Number(dimensionsRaw) : undefined;
+
+  const portRaw = process.env.MEMORYD_PORT;
+  const port = portRaw ? Number(portRaw) : 3200;
+
+  return {
+    sidecarPath: overrides?.sidecarPath
+      ?? process.env.MEMORYD_SIDECAR_PATH
+      ?? DEFAULT_SIDECAR_PATH,
+
+    embedding: overrides?.embedding ?? {
+      provider,
+      model    : process.env.MEMORYD_EMBEDDING_MODEL,
+      dimensions,
+      endpoint : process.env.MEMORYD_EMBEDDING_URL,
+      apiKey   : process.env.OPENAI_API_KEY,
+    },
+
+    host: overrides?.host
+      ?? process.env.MEMORYD_HOST
+      ?? 'localhost',
+
+    port: overrides?.port ?? port,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,3 +63,6 @@ export { registerTaskResources } from './mcp/resources/task-resources.js';
 
 export { registerContextPrompt } from './mcp/prompts/context-prompt.js';
 export { registerPlanPrompt } from './mcp/prompts/plan-prompt.js';
+
+export { resolveConfig } from './config.js';
+export type { MemorydConfig } from './config.js';

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { resolveConfig } from '../src/config.js';
+
+describe('resolveConfig', () => {
+  const envBackup: Record<string, string | undefined> = {};
+
+  const VARS = [
+    'MEMORYD_SIDECAR_PATH',
+    'MEMORYD_EMBEDDING_PROVIDER',
+    'MEMORYD_EMBEDDING_MODEL',
+    'MEMORYD_EMBEDDING_URL',
+    'MEMORYD_EMBEDDING_DIMENSIONS',
+    'OPENAI_API_KEY',
+    'MEMORYD_HOST',
+    'MEMORYD_PORT',
+  ] as const;
+
+  beforeEach(() => {
+    for (const key of VARS) {
+      envBackup[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of VARS) {
+      if (envBackup[key] !== undefined) {
+        process.env[key] = envBackup[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('returns defaults when no env vars are set', () => {
+    const config = resolveConfig();
+    expect(config.sidecarPath).toContain('.memoryd');
+    expect(config.sidecarPath).toEndWith('index.db');
+    expect(config.embedding.provider).toBe('noop');
+    expect(config.host).toBe('localhost');
+    expect(config.port).toBe(3200);
+  });
+
+  it('reads sidecar path from env', () => {
+    process.env.MEMORYD_SIDECAR_PATH = '/tmp/test.db';
+    const config = resolveConfig();
+    expect(config.sidecarPath).toBe('/tmp/test.db');
+  });
+
+  it('reads embedding provider from env', () => {
+    process.env.MEMORYD_EMBEDDING_PROVIDER = 'ollama';
+    process.env.MEMORYD_EMBEDDING_MODEL = 'nomic-embed-text';
+    process.env.MEMORYD_EMBEDDING_URL = 'http://gpu:11434';
+    const config = resolveConfig();
+    expect(config.embedding.provider).toBe('ollama');
+    expect(config.embedding.model).toBe('nomic-embed-text');
+    expect(config.embedding.endpoint).toBe('http://gpu:11434');
+  });
+
+  it('reads OpenAI API key from env', () => {
+    process.env.MEMORYD_EMBEDDING_PROVIDER = 'openai';
+    process.env.OPENAI_API_KEY = 'sk-test-123';
+    const config = resolveConfig();
+    expect(config.embedding.provider).toBe('openai');
+    expect(config.embedding.apiKey).toBe('sk-test-123');
+  });
+
+  it('reads embedding dimensions from env', () => {
+    process.env.MEMORYD_EMBEDDING_DIMENSIONS = '384';
+    const config = resolveConfig();
+    expect(config.embedding.dimensions).toBe(384);
+  });
+
+  it('reads host and port from env', () => {
+    process.env.MEMORYD_HOST = '0.0.0.0';
+    process.env.MEMORYD_PORT = '8080';
+    const config = resolveConfig();
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.port).toBe(8080);
+  });
+
+  it('overrides take precedence over env vars', () => {
+    process.env.MEMORYD_SIDECAR_PATH = '/tmp/env.db';
+    process.env.MEMORYD_PORT = '9999';
+    const config = resolveConfig({
+      sidecarPath : '/tmp/override.db',
+      port        : 4000,
+    });
+    expect(config.sidecarPath).toBe('/tmp/override.db');
+    expect(config.port).toBe(4000);
+  });
+
+  it('partial overrides leave other fields from env', () => {
+    process.env.MEMORYD_HOST = '0.0.0.0';
+    const config = resolveConfig({ port: 5000 });
+    expect(config.port).toBe(5000);
+    expect(config.host).toBe('0.0.0.0');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/config.ts` — centralized runtime configuration module that resolves env vars with sensible defaults
- Move `@enbox/agent` from `devDependencies` to `dependencies` (it's imported at runtime in `connectAgent()`)
- Add 8 tests for config resolution

Closes #41

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `MEMORYD_SIDECAR_PATH` | `~/.memoryd/index.db` | SQLite sidecar location |
| `MEMORYD_EMBEDDING_PROVIDER` | `noop` | `ollama` / `openai` / `noop` |
| `MEMORYD_EMBEDDING_MODEL` | provider default | Model name |
| `MEMORYD_EMBEDDING_URL` | `http://localhost:11434` | Ollama endpoint |
| `MEMORYD_EMBEDDING_DIMENSIONS` | provider default | Vector dimensions |
| `OPENAI_API_KEY` | — | OpenAI API key |
| `MEMORYD_HOST` | `localhost` | HTTP server bind address |
| `MEMORYD_PORT` | `3200` | HTTP server port |

## Verification

- `bun run build` — Zero TypeScript errors
- `bun test .spec.ts` — 231 tests pass (8 new), 0 failures
- `bun run lint` — Zero ESLint warnings/errors